### PR TITLE
fix: Fmθスコアの正規化レンジを実測分布に合わせる

### DIFF
--- a/lib/segment_analysis.py
+++ b/lib/segment_analysis.py
@@ -569,9 +569,13 @@ def calculate_meditation_score(
     scores = {}
 
     # Fmθスコア（高いほど良い）
-    # 旧: 50-200 μV² → 新: 17-23 dB (10*log10(50) ≈ 17, 10*log10(200) ≈ 23)
+    # レンジは実測分布から決定（2026-06〜07の5セッション）:
+    #   セッション平均 -2.37〜+0.35 dB、瞬時値 -5.18〜+6.20 dB
+    # 単位をμV²からdBへ移行した際、旧レンジ50-200 μV²に10*log10を適用した
+    # 17-23 dBが残っていたが、これは実測値と全く重ならず常時下限クリップされ、
+    # 重み最大(0.3125)のFmθスコアが恒常的に0となり総合スコアの上限が68.8だった。
     if fmtheta is not None:
-        scores['fmtheta'] = _normalize_indicator(fmtheta, min_val=17.0, max_val=23.0)
+        scores['fmtheta'] = _normalize_indicator(fmtheta, min_val=-5.0, max_val=5.0)
     else:
         scores['fmtheta'] = 0.5
 

--- a/tests/test_phase3_bels_conversion.py
+++ b/tests/test_phase3_bels_conversion.py
@@ -85,14 +85,19 @@ def test_faa_bels_output():
 
 def test_meditation_score_normalization():
     """総合スコアの正規化範囲がdBに対応していることを確認"""
-    # Fmθ: 17-23 dB の範囲でテスト
-    score_min = calculate_meditation_score(fmtheta=17.0)
-    score_max = calculate_meditation_score(fmtheta=23.0)
-    score_mid = calculate_meditation_score(fmtheta=20.0)
+    # Fmθ: -5.0 ~ +5.0 dB の範囲でテスト（実測分布に基づくレンジ）
+    score_min = calculate_meditation_score(fmtheta=-5.0)
+    score_max = calculate_meditation_score(fmtheta=5.0)
+    score_mid = calculate_meditation_score(fmtheta=0.0)
 
     assert score_min['scores']['fmtheta'] == 0.0  # min値で0
     assert score_max['scores']['fmtheta'] == 1.0  # max値で1
     assert 0.4 < score_mid['scores']['fmtheta'] < 0.6  # 中間値で約0.5
+
+    # 実測レンジのFmθがクリップされず中間域に入ること（回帰防止）
+    for observed in (-2.37, -1.34, 0.35):
+        s = calculate_meditation_score(fmtheta=observed)['scores']['fmtheta']
+        assert 0.0 < s < 1.0, f'Fmθ={observed} がクリップされている'
 
     # FAA: -20.0 ~ 20.0 dB の範囲でテスト
     faa_min = calculate_meditation_score(faa=-20.0)


### PR DESCRIPTION
## 背景

単位を μV² から dB へ移行した際、旧レンジ `50-200 μV²` に `10*log10` を適用した
`17-23 dB` が正規化レンジとして残っていた。

しかし実測の Fmθ はこのレンジと全く重ならない:

| セッション | mean | min | max |
|---|---:|---:|---:|
| 2026-06-10 | 0.35 | -2.75 | 6.20 |
| 2026-07-11 | -2.37 | -5.18 | 3.95 |
| 2026-07-16 | -2.37 | -4.52 | 3.28 |
| 2026-07-19 | -1.96 | -4.46 | 3.48 |
| 2026-07-22 | -0.37 | -2.88 | 5.30 |

## 影響

Fmθ は常時下限クリップされ、スコアが恒常的に 0 だった。
Fmθ は重み最大（0.3125）のため、**総合スコアの実質上限が 68.8/100 に固定**され、
評価レベル「優秀」（80以上）は構造的に到達不能だった。

- Fmθ以外すべて満点 : 68.8 / 100 ← 修正前の上限
- Fmθも満点 : 100.0 / 100 ← 修正後

## 変更内容

- 正規化レンジを実測分布に基づく `-5.0 〜 +5.0 dB` へ修正
- 誤ったレンジを固定していたテストを更新
- 実測値がクリップされないことを確認する回帰テストを追加

レンジは n=5 のため round な対称値を採用し、過学習を避けた。

## Test plan

- [x] `pytest tests/` → 4 passed, 10 skipped
- [x] 2026-07-22 セッションでレポート再生成: 総合スコア 44.1 → 58.6（Fmθ内訳 0.0 → 46.3）

## 残課題（本PR対象外）

- FAA・HSI品質は scores に算出されるが MEDITATION_SCORE_WEIGHTS にキーが無く合計から黙って落ちている
- FAA はテンプレートに描画セクションが無く、レポートに出力されない

---
🤖 Claude Code session: `b1afe308-0b1c-4773-8297-d3b913a40b3e`