### PR TITLE
refactor: frontal_theta と smr の重複実装を共通基盤に集約

### DIFF
--- a/lib/sensors/eeg/_band_power_base.py
+++ b/lib/sensors/eeg/_band_power_base.py
@@ -1,0 +1,165 @@
+"""
+帯域パワー計算の共通基盤 - Frontal Midline Theta (Fmθ) と SMR の共通ロジック。
+
+このモジュールは、frontal_theta.py と smr.py に共通する以下の処理を集約する:
+raw準備 → band解決 → Hilbert変換によるチャネル平均パワー計算 → 統計DataFrame作成 → メタデータ作成
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Optional, Sequence, Tuple
+
+import pandas as pd
+import mne
+
+from .preprocessing import prepare_mne_raw
+from .core.hilbert_power import calculate_channel_average_power
+from .core.statistics import calculate_half_comparison, create_statistics_dataframe, create_metadata
+
+
+@dataclass
+class BandPowerComputation:
+    """帯域パワー計算結果を保持するデータクラス。"""
+
+    time_series: pd.Series
+    statistics: pd.DataFrame
+    metadata: dict
+    raw: mne.io.BaseRaw
+    channels: list
+    start_time: pd.Timestamp
+
+
+def prepare_raw_for_channels(
+    df: pd.DataFrame,
+    channels: Sequence[str],
+    sfreq: Optional[float] = None,
+) -> mne.io.BaseRaw:
+    """指定チャネルのみ抽出したRawオブジェクトを取得。"""
+    mne_dict = prepare_mne_raw(df, sfreq=sfreq)
+    if not mne_dict:
+        raise ValueError('Failed to construct RAW data.')
+
+    raw = mne_dict['raw'].copy()
+    available = set(raw.ch_names)
+    missing = [ch for ch in channels if ch not in available]
+    if missing:
+        raise ValueError(f'Specified channels not found: {missing}')
+
+    return raw
+
+
+def resolve_band(
+    band: Optional[Tuple[float, float]],
+    band_key: Optional[str],
+    band_options: Dict[str, Tuple[float, float]],
+    default_key: str,
+    band_label_for_error: str,
+) -> Tuple[Tuple[float, float], str]:
+    """band指定を優先し、なければband_key（未指定時はdefault_key）をband_optionsから解決する。"""
+    if band is not None:
+        return band, 'custom'
+
+    key = band_key or default_key
+    if key not in band_options:
+        raise ValueError(f'未定義の{band_label_for_error}帯域キーです: {key}')
+    return band_options[key], key
+
+
+def calculate_band_power(
+    df: pd.DataFrame,
+    *,
+    channels: Optional[Sequence[str]] = None,
+    band: Optional[Tuple[float, float]] = None,
+    band_key: Optional[str] = None,
+    band_options: Dict[str, Tuple[float, float]],
+    default_band_key: str,
+    band_label_for_error: str,
+    empty_series_message: str,
+    metadata_extra: Optional[dict] = None,
+    resample_interval: str = '10s',
+    smoothing_seconds: float = 6.0,
+    rolling_window_seconds: float = 8.0,
+    raw: Optional[mne.io.BaseRaw] = None,
+    default_channels: Sequence[str] = ('RAW_AF7', 'RAW_AF8'),
+) -> BandPowerComputation:
+    """
+    帯域パワー（dB単位）の時系列・統計・メタデータを計算する共通処理。
+
+    Fmθ/SMRいずれの計算も、band解決 → Raw準備 → チャネル平均パワー計算 → 統計DataFrame作成
+    → メタデータ作成、という共通手順を辿るため、その部分をここに集約する。
+    """
+    if channels is None:
+        channels = default_channels
+
+    channel_list = list(channels)
+
+    band_tuple, band_label = resolve_band(
+        band, band_key, band_options, default_band_key, band_label_for_error
+    )
+
+    # RAWデータ準備
+    if raw is None:
+        raw = prepare_raw_for_channels(df, channel_list)
+    else:
+        raw = raw.copy()
+
+    # セッション開始時刻
+    start_time = pd.to_datetime(df['TimeStamp'].min())
+
+    # 処理パラメータ
+    processing_params = {
+        'resample_interval': resample_interval,
+        'smoothing_seconds': smoothing_seconds,
+        'rolling_window_seconds': rolling_window_seconds,
+    }
+
+    # ヒルベルト変換でバンドパワー計算（チャネル平均）
+    series = calculate_channel_average_power(
+        raw=raw,
+        band=band_tuple,
+        channels=channel_list,
+        start_time=start_time,
+        resample_interval=resample_interval,
+        smoothing_seconds=smoothing_seconds,
+        rolling_window_seconds=rolling_window_seconds,
+        outlier_percentile=0.90,
+    )
+
+    if series.empty:
+        raise ValueError(empty_series_message)
+
+    # 統計DataFrame作成
+    stats_df = create_statistics_dataframe(
+        series,
+        name='Value',
+        unit='dB',
+        include_half_comparison=True,
+    )
+    # Unit列を削除（後方互換性のため）
+    if 'Unit' in stats_df.columns:
+        stats_df = stats_df.drop(columns=['Unit'])
+
+    # メタデータ作成
+    metadata = create_metadata(
+        series=series,
+        band=band_tuple,
+        channels=channel_list,
+        sfreq=float(raw.info['sfreq']),
+        processing_params=processing_params,
+        extra={'band_key': band_label, **(metadata_extra or {})},
+    )
+
+    # 後方互換性のためのキー追加
+    half_stats = calculate_half_comparison(series)
+    metadata['increase_db'] = half_stats['change_db']
+    metadata['increase_rate_percent'] = half_stats['change_percent']
+
+    return BandPowerComputation(
+        time_series=series,
+        statistics=stats_df,
+        metadata=metadata,
+        raw=raw,
+        channels=channel_list,
+        start_time=start_time,
+    )

--- a/lib/sensors/eeg/frontal_theta.py
+++ b/lib/sensors/eeg/frontal_theta.py
@@ -10,15 +10,13 @@ Fmθパワーの時系列と統計指標を算出する。
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Dict, Iterable, Optional, Sequence, Tuple
+from typing import Dict, Iterable, Optional, Tuple
 
-import numpy as np
 import pandas as pd
 import mne
 
-from .preprocessing import prepare_mne_raw
-from .core.hilbert_power import calculate_hilbert_band_power, calculate_channel_average_power
-from .core.statistics import calculate_half_comparison, create_statistics_dataframe, create_metadata
+from .core.hilbert_power import calculate_channel_average_power
+from ._band_power_base import calculate_band_power
 
 # 代表的なFmθ帯域プリセット（必要に応じて切り替え可能）
 FMTHETA_BAND_OPTIONS: Dict[str, Tuple[float, float]] = {
@@ -36,25 +34,6 @@ class FrontalThetaResult:
     statistics: pd.DataFrame
     metadata: dict
     alpha_series: Optional[pd.Series] = None  # アルファ波時系列（オプション）
-
-
-def _prepare_raw_for_channels(
-    df: pd.DataFrame,
-    channels: Sequence[str],
-    sfreq: Optional[float] = None,
-) -> mne.io.BaseRaw:
-    """指定チャネルのみ抽出したRawオブジェクトを取得。"""
-    mne_dict = prepare_mne_raw(df, sfreq=sfreq)
-    if not mne_dict:
-        raise ValueError('Failed to construct RAW data.')
-
-    raw = mne_dict['raw'].copy()
-    available = set(raw.ch_names)
-    missing = [ch for ch in channels if ch not in available]
-    if missing:
-        raise ValueError(f'Specified channels not found: {missing}')
-
-    return raw
 
 
 def calculate_frontal_theta(
@@ -100,96 +79,39 @@ def calculate_frontal_theta(
         時系列パワーはdB単位（10*log10(μV²)）で出力される。
         include_alpha=Trueの場合、alpha_seriesにアルファ波時系列も含まれる。
     """
-    if channels is None:
-        channels = ('RAW_AF7', 'RAW_AF8')
-
-    channel_list = list(channels)
-
-    if band is not None:
-        band_tuple = band
-        band_label = 'custom'
-    else:
-        key = band_key or 'narrow'
-        if key not in FMTHETA_BAND_OPTIONS:
-            raise ValueError(f'未定義のFmθ帯域キーです: {key}')
-        band_tuple = FMTHETA_BAND_OPTIONS[key]
-        band_label = key
-
-    # RAWデータ準備
-    if raw is None:
-        raw = _prepare_raw_for_channels(df, channel_list)
-    else:
-        raw = raw.copy()
-
-    # セッション開始時刻
-    start_time = pd.to_datetime(df['TimeStamp'].min())
-
-    # 処理パラメータ
-    processing_params = {
-        'resample_interval': resample_interval,
-        'smoothing_seconds': smoothing_seconds,
-        'rolling_window_seconds': rolling_window_seconds,
-    }
-
-    # ヒルベルト変換でバンドパワー計算（チャネル平均）
-    theta_series = calculate_channel_average_power(
-        raw=raw,
-        band=band_tuple,
-        channels=channel_list,
-        start_time=start_time,
+    computation = calculate_band_power(
+        df,
+        channels=channels,
+        band=band,
+        band_key=band_key,
+        band_options=FMTHETA_BAND_OPTIONS,
+        default_band_key='narrow',
+        band_label_for_error='Fmθ',
+        empty_series_message='Fmθ time series is empty.',
         resample_interval=resample_interval,
         smoothing_seconds=smoothing_seconds,
         rolling_window_seconds=rolling_window_seconds,
-        outlier_percentile=0.90,
+        raw=raw,
     )
-
-    if theta_series.empty:
-        raise ValueError('Fmθ time series is empty.')
-
-    # 統計DataFrame作成
-    stats_df = create_statistics_dataframe(
-        theta_series,
-        name='Value',
-        unit='dB',
-        include_half_comparison=True,
-    )
-    # Unit列を削除（後方互換性のため）
-    if 'Unit' in stats_df.columns:
-        stats_df = stats_df.drop(columns=['Unit'])
-
-    # メタデータ作成
-    metadata = create_metadata(
-        series=theta_series,
-        band=band_tuple,
-        channels=channel_list,
-        sfreq=float(raw.info['sfreq']),
-        processing_params=processing_params,
-        extra={'band_key': band_label},
-    )
-
-    # 後方互換性のためのキー追加
-    half_stats = calculate_half_comparison(theta_series)
-    metadata['increase_db'] = half_stats['change_db']
-    metadata['increase_rate_percent'] = half_stats['change_percent']
 
     # アルファ波の計算（オプション）
     alpha_series_final = None
     if include_alpha:
         alpha_series_final = calculate_channel_average_power(
-            raw=raw,
+            raw=computation.raw,
             band=alpha_band,
-            channels=channel_list,
-            start_time=start_time,
+            channels=computation.channels,
+            start_time=computation.start_time,
             resample_interval=resample_interval,
             smoothing_seconds=smoothing_seconds,
             rolling_window_seconds=rolling_window_seconds,
             outlier_percentile=0.90,
         )
-        metadata['alpha_band'] = alpha_band
+        computation.metadata['alpha_band'] = alpha_band
 
     return FrontalThetaResult(
-        time_series=theta_series,
-        statistics=stats_df,
-        metadata=metadata,
+        time_series=computation.time_series,
+        statistics=computation.statistics,
+        metadata=computation.metadata,
         alpha_series=alpha_series_final,
     )

--- a/lib/sensors/eeg/smr.py
+++ b/lib/sensors/eeg/smr.py
@@ -27,13 +27,7 @@ from typing import Dict, Iterable, Optional, Tuple
 import pandas as pd
 import mne
 
-from .preprocessing import prepare_mne_raw
-from .core.hilbert_power import calculate_channel_average_power
-from .core.statistics import (
-    calculate_half_comparison,
-    create_statistics_dataframe,
-    create_metadata,
-)
+from ._band_power_base import calculate_band_power
 
 # SMR帯域の定義
 SMR_BAND: Tuple[float, float] = (12.0, 15.0)
@@ -52,25 +46,6 @@ class SMRResult:
     time_series: pd.Series  # SMRパワー時系列 (dB)
     statistics: pd.DataFrame
     metadata: dict
-
-
-def _prepare_raw_for_channels(
-    df: pd.DataFrame,
-    channels: list,
-    sfreq: Optional[float] = None,
-) -> mne.io.BaseRaw:
-    """指定チャネルを含むRawオブジェクトを取得。"""
-    mne_dict = prepare_mne_raw(df, sfreq=sfreq)
-    if not mne_dict:
-        raise ValueError('Failed to construct RAW data.')
-
-    raw = mne_dict['raw'].copy()
-    available = set(raw.ch_names)
-    missing = [ch for ch in channels if ch not in available]
-    if missing:
-        raise ValueError(f'Specified channels not found: {missing}')
-
-    return raw
 
 
 def calculate_smr(
@@ -119,83 +94,24 @@ def calculate_smr(
     - 実測データでは、AF領域でSMR帯域が鮮明に観察されることがある
     - これは前頭葉の注意制御・集中活動を反映している可能性がある
     """
-    if channels is None:
-        channels = ('RAW_AF7', 'RAW_AF8')
-
-    channel_list = list(channels)
-
-    if band is not None:
-        band_tuple = band
-        band_label = 'custom'
-    else:
-        key = band_key or 'narrow'
-        if key not in SMR_BAND_OPTIONS:
-            raise ValueError(f'未定義のSMR帯域キーです: {key}')
-        band_tuple = SMR_BAND_OPTIONS[key]
-        band_label = key
-
-    # RAWデータ準備
-    if raw is None:
-        raw = _prepare_raw_for_channels(df, channel_list)
-    else:
-        raw = raw.copy()
-
-    # セッション開始時刻
-    start_time = pd.to_datetime(df['TimeStamp'].min())
-
-    # 処理パラメータ
-    processing_params = {
-        'resample_interval': resample_interval,
-        'smoothing_seconds': smoothing_seconds,
-        'rolling_window_seconds': rolling_window_seconds,
-    }
-
-    # ヒルベルト変換でバンドパワー計算（チャネル平均）
-    smr_series = calculate_channel_average_power(
-        raw=raw,
-        band=band_tuple,
-        channels=channel_list,
-        start_time=start_time,
+    computation = calculate_band_power(
+        df,
+        channels=channels,
+        band=band,
+        band_key=band_key,
+        band_options=SMR_BAND_OPTIONS,
+        default_band_key='narrow',
+        band_label_for_error='SMR',
+        empty_series_message='SMR time series is empty.',
+        metadata_extra={'measurement_note': 'AF領域での測定（本来のSMRはC3/C4）'},
         resample_interval=resample_interval,
         smoothing_seconds=smoothing_seconds,
         rolling_window_seconds=rolling_window_seconds,
-        outlier_percentile=0.90,
+        raw=raw,
     )
-
-    if smr_series.empty:
-        raise ValueError('SMR time series is empty.')
-
-    # 統計DataFrame作成
-    stats_df = create_statistics_dataframe(
-        smr_series,
-        name='Value',
-        unit='dB',
-        include_half_comparison=True,
-    )
-    # Unit列を削除（後方互換性のため）
-    if 'Unit' in stats_df.columns:
-        stats_df = stats_df.drop(columns=['Unit'])
-
-    # メタデータ作成
-    metadata = create_metadata(
-        series=smr_series,
-        band=band_tuple,
-        channels=channel_list,
-        sfreq=float(raw.info['sfreq']),
-        processing_params=processing_params,
-        extra={
-            'band_key': band_label,
-            'measurement_note': 'AF領域での測定（本来のSMRはC3/C4）',
-        },
-    )
-
-    # 後方互換性のためのキー追加
-    half_stats = calculate_half_comparison(smr_series)
-    metadata['increase_db'] = half_stats['change_db']
-    metadata['increase_rate_percent'] = half_stats['change_percent']
 
     return SMRResult(
-        time_series=smr_series,
-        statistics=stats_df,
-        metadata=metadata,
+        time_series=computation.time_series,
+        statistics=computation.statistics,
+        metadata=computation.metadata,
     )


### PR DESCRIPTION
## 概要

- `lib/sensors/eeg/_band_power_base.py` を新設し、`frontal_theta.py` / `smr.py` に重複していた「raw準備 → band解決 → Hilbertパワー計算 → 統計DataFrame作成 → メタデータ作成」の共通処理を集約
- `frontal_theta.py` / `smr.py` を薄いラッパに書き換え（`FrontalThetaResult` / `SMRResult` の公開インタフェースは変更なし）
- PAF/ITF が `_peak_frequency_base.py` に共通化された前例と同じパターンを踏襲

Closes #20

## テスト計画

- [x] import 確認:
  ```
  python -c "from lib import calculate_frontal_theta, calculate_smr, FrontalThetaResult, SMRResult, SMR_BAND; print('ok')"
  ```
  → `ok`
- [x] 数値等価性テスト: 実データ（`data/muse/mindMonitor_2026-07-28--06-47-38_1433097217139273238.csv`）で変更前後の `calculate_frontal_theta` / `calculate_smr` の統計値・メタデータが完全一致することを確認
  ```
  diff before.json after.json
  diff before_fmtheta_stats.csv after_fmtheta_stats.csv
  diff before_smr_stats.csv after_smr_stats.csv
  ```
  → いずれも差分なし（exit 0）
- [x] 回帰確認: `python scripts/generate_report.py --data <上記CSV> --output <一時ディレクトリ>` がエラーなく完走することを確認

---
🤖 Claude Code session: `0852651e-2160-4f7c-8dfd-80b0ddc92448`
