### PR TITLE
fix: summary.csv のバンド比率欠落とレポートのFAAセクション欠落を修正

### DIFF
--- a/lib/report/steps_eeg.py
+++ b/lib/report/steps_eeg.py
@@ -106,6 +106,7 @@ def analyze_faa(df, raw_unfiltered, results):
     print('計算中: Frontal Alpha Asymmetry...')
     faa_result = calculate_frontal_asymmetry(df, raw=raw_unfiltered)
     results['faa_stats'] = faa_result.statistics
+    results['faa_interpretation'] = faa_result.metadata.get('interpretation')
     return faa_result
 
 

--- a/lib/report/steps_summary.py
+++ b/lib/report/steps_summary.py
@@ -13,7 +13,6 @@ from lib import (
 from lib.session_log import write_to_csv, write_to_google_sheets
 from lib.sensors.eeg.visualization import plot_band_ratios
 from lib.visualization import plot_segment_comparison
-from lib.sensors.imu import PostureAnalyzer
 from lib.statistical_dataframe import create_statistical_dataframe
 
 from .step import analysis_step
@@ -47,10 +46,6 @@ def build_statistical_dataframe(
     if 'posture' in statistical_df and not statistical_df['posture'].empty:
         print(f'  Posture統計量: {len(statistical_df["posture"])} セグメント')
         posture_df = statistical_df['posture']
-
-        # 後方互換性のため、PostureAnalyzer でもサマリーを計算
-        posture_analyzer = PostureAnalyzer()
-        posture_analyzer.compute_summary(df)
 
         # posture詳細テーブルを追加
         if 'posture' not in results:

--- a/lib/session_summary.py
+++ b/lib/session_summary.py
@@ -127,37 +127,17 @@ def generate_session_summary(
         summary['hsi_quality_score'] = hsi_data.get('overall_quality')
         summary['hsi_good_ratio'] = hsi_data.get('good_ratio', 0.0)
 
-    # バンド比率（新しい縦長形式に対応）
+    # バンド比率（Metric名は create_statistical_dataframe の f'{metric_key}_Mean' 形式）
     if 'band_ratios_stats' in results:
         ratios_df = results['band_ratios_stats']
 
-        # Beta/Alpha（覚醒度）
-        beta_alpha_mean = extract_metric_value(ratios_df, 'beta_alpha_Mean')
-        if beta_alpha_mean is None:
-            # 旧形式（横長）への後方互換
-            old_row = ratios_df[ratios_df.get('Metric', ratios_df.get('指標', pd.Series())) == 'Beta/Alpha']
-            if not old_row.empty:
-                beta_alpha_mean = old_row.get('Value', old_row.get('平均値', pd.Series())).iloc[0]
-
-        summary['beta_alpha_ratio_mean'] = beta_alpha_mean
-
-        # Beta/Theta（集中度）
-        beta_theta_mean = extract_metric_value(ratios_df, 'Beta/Theta Mean')
-        if beta_theta_mean is None:
-            old_row = ratios_df[ratios_df.get('Metric', ratios_df.get('指標', pd.Series())) == 'Beta/Theta']
-            if not old_row.empty:
-                beta_theta_mean = old_row.get('Value', old_row.get('平均値', pd.Series())).iloc[0]
-
-        summary['beta_theta_ratio_mean'] = beta_theta_mean
-
-        # Theta/Alpha（瞑想深度）
-        theta_alpha_mean = extract_metric_value(ratios_df, 'Theta/Alpha Mean')
-        if theta_alpha_mean is None:
-            old_row = ratios_df[ratios_df.get('Metric', ratios_df.get('指標', pd.Series())) == 'Theta/Alpha']
-            if not old_row.empty:
-                theta_alpha_mean = old_row.get('Value', old_row.get('平均値', pd.Series())).iloc[0]
-
-        summary['theta_alpha_ratio_mean'] = theta_alpha_mean
+        ratio_columns = {
+            'beta_alpha_ratio_mean': 'beta_alpha',   # 覚醒度
+            'beta_theta_ratio_mean': 'beta_theta',   # 集中度
+            'theta_alpha_ratio_mean': 'theta_alpha',  # 瞑想深度
+        }
+        for summary_key, metric_key in ratio_columns.items():
+            summary[summary_key] = extract_metric_value(ratios_df, f'{metric_key}_Mean')
 
     # Fmθ
     if 'frontal_theta_stats' in results:

--- a/lib/templates/renderer.py
+++ b/lib/templates/renderer.py
@@ -209,6 +209,13 @@ class MeditationReportRenderer:
                 'stats': results.get('alpha_power_stats'),
             }
 
+        # FAA（前頭アルファ非対称）
+        if 'faa_stats' in results:
+            indicators['faa'] = {
+                'stats': results.get('faa_stats'),
+                'interpretation': results.get('faa_interpretation'),
+            }
+
         # Band Ratios
         if 'band_ratios_img' in results:
             indicators['band_ratios'] = {

--- a/scripts/generate_report.py
+++ b/scripts/generate_report.py
@@ -12,13 +12,10 @@ Usage:
 import sys
 from pathlib import Path
 import argparse
-from datetime import datetime
 
-import numpy as np
-import pandas as pd
 import matplotlib
+# lib 側が pyplot を import する前にバックエンドを固定する
 matplotlib.use("Agg")
-import matplotlib.pyplot as plt
 
 # プロジェクトルートをパスに追加
 project_root = Path(__file__).resolve().parents[1]

--- a/templates/meditation/sections/characteristic_indicators.md.j2
+++ b/templates/meditation/sections/characteristic_indicators.md.j2
@@ -40,6 +40,24 @@
 
 {% endif %}
 
+{% if indicators.faa %}
+### Frontal Alpha Asymmetry (FAA)
+
+{% if indicators.faa.interpretation %}
+**判定**: {{ indicators.faa.interpretation }}
+
+{% endif %}
+{% if indicators.faa.stats is not none %}
+{% set faa_df = indicators.faa.stats[indicators.faa.stats['Metric'] != 'Interpretation'] %}
+{{ faa_df|df_to_markdown(floatfmt='.3f', index=False, standardize_columns=True) }}
+
+{% endif %}
+> **解釈**: FAA = 右α(dB) − 左α(dB)。αパワーは皮質活動と逆相関するため、
+> 正値は左前頭優位（接近動機・ポジティブ傾向）、負値は右前頭優位（回避動機・ネガティブ傾向）を示唆します。
+> ±2.0 dB 以内は Balanced として扱います。
+
+{% endif %}
+
 {% if indicators.band_ratios %}
 ### バンド比率指標
 


### PR DESCRIPTION
2026-08-07 の `/daily-review` 実行中に見つかった2件のレポート生成バグを修正する。どちらも解析ロジックではなく出力層の問題で、算出済みの値が出力に届いていなかった。

## 1. summary.csv のバンド比率が空になる

`lib/session_summary.py` が参照する Metric 名が `create_statistical_dataframe` の出力形式（`f'{metric_key}_Mean'`）と一致していなかった。`beta_alpha` のみ正しく `'beta_alpha_Mean'` を指定していたため、`beta_theta_ratio_mean` と `theta_alpha_ratio_mean` の2つだけが空欄で出力されていた。

- 3つの同型コピペブロックを dict ループに集約し、Metric 名を実際の形式に統一
- 到達不能だった旧横長形式へのフォールバックを削除（新形式では `Metric` 列が `'Beta/Theta'` 等になることはない）

## 2. REPORT.md にFAAセクションが無い

FAA は計算され `results['faa_stats']` に格納されていたが、`renderer.py` が context に渡していなかったため REPORT.md に出力されず、`summary.csv` の `faa_mean` からしか読めなかった。

- `steps_eeg.py`: `metadata['interpretation']` を results に格納
- `renderer.py`: `indicators['faa']` を context に追加
- `characteristic_indicators.md.j2`: FAAセクションを追加。`Value` 列が文字列混在になるのを避けるため `Interpretation` 行は数値テーブルから除外し、判定として別行で表示

## 3. 併せて dead code を削除

上記2件とは独立した、元から手元にあった変更。

- `steps_summary.py`: 戻り値を捨てている `PostureAnalyzer.compute_summary()` 呼び出し
- `generate_report.py`: 未使用 import（`datetime` / `numpy` / `pandas` / `pyplot`）。`matplotlib.use("Agg")` の意図をコメントで明示

## Test plan

型チェッカーはこのプロジェクトに未設定（mypy 未インストール、pyproject.toml/setup.cfg なし）のため、構文チェック・テスト・実データでの再生成で検証した。

\`\`\`
$ venv/bin/python -m py_compile lib/report/steps_eeg.py lib/report/steps_summary.py lib/session_summary.py lib/templates/renderer.py scripts/generate_report.py
compile OK

$ venv/bin/python -m pytest tests/ -q
..................ssssssssss                                             [100%]
18 passed, 10 skipped in 3.52s
\`\`\`

skip 10件は `data/sample.csv` 不在によるIAFテストで、この変更とは無関係（既知）。

実データ（`mindMonitor_2026-08-07--07-37-48`）で `bash scripts/run_analysis.sh` を再実行:

\`\`\`
$ venv/bin/python -c "import pandas as pd; d = pd.read_csv('tmp/summary.csv'); ..."
beta_alpha_ratio_mean = 0.0803596088953636
beta_theta_ratio_mean = 0.2059240719286684
theta_alpha_ratio_mean = 0.4132458496318945
faa_mean = 0.6127939495284983
\`\`\`

修正前は `beta_theta_ratio_mean` と `theta_alpha_ratio_mean` が空欄。修正後の θ/α = 0.413 はレポート本文の主要指標サマリー（0.413）と一致し、β/θ = 0.206 も区間別の値（0.15〜0.30）の範囲内。

REPORT.md に出力されたFAAセクション:

\`\`\`
### Frontal Alpha Asymmetry (FAA)

**判定**: Balanced

| Metric           |   Value | Unit   |
|:-----------------|--------:|:-------|
| Mean FAA         |   0.613 | dB     |
| Median           |   0.612 | dB     |
| Std Dev          |   0.646 | dB     |
| First Half Mean  |   0.741 | dB     |
| Second Half Mean |   0.484 | dB     |
\`\`\`

---
🤖 Claude Code session: \`$CLAUDE_SESSION_ID\`