### PR TITLE
chore: ruff / mypy / pytest による check 環境を整備

### DIFF
--- a/lib/__init__.py
+++ b/lib/__init__.py
@@ -2,76 +2,61 @@
 Mind Monitor Analysis Library
 """
 
-from .loaders import (
-    load_mind_monitor_csv,
-    get_eeg_data,
-    get_optics_data,
-    get_heart_rate_data,
-    get_data_summary
+from .loaders import get_data_summary, get_eeg_data, get_heart_rate_data, get_optics_data, load_mind_monitor_csv
+from .segment_analysis import (
+    MEDITATION_SCORE_WEIGHTS,
+    SegmentAnalysisResult,
+    calculate_best_metrics,
+    calculate_meditation_score,
+    calculate_segment_analysis,
 )
-
-from .sensors.fnirs import (
-    calculate_hbo_hbr,
-    analyze_fnirs
-)
-
-from .sensors.imu import (
-    analyze_motion,
-    MOTION_THRESHOLDS,
-)
-
 from .sensors.eeg import (
-    calculate_band_statistics,
-    calculate_hsi_statistics,
-    summarize_artifacts,
-    calculate_amplitude_statistics,
-    detect_artifact_windows,
-    prepare_mne_raw,
-    filter_eeg_quality,
-    calculate_psd,
-    calculate_spectrogram,
-    calculate_spectrogram_all_channels,
-    calculate_paf,
-    calculate_itf,
-    get_psd_peak_frequencies,
+    DETAILED_FREQ_BANDS,
     FREQ_BANDS,
-    FrontalThetaResult,
-    calculate_frontal_theta,
-    FrontalAsymmetryResult,
-    calculate_frontal_asymmetry,
-    AlphaPowerResult,
+    SMR_BAND,
     AlphaPowerMethod,
-    calculate_alpha_power,
-    calculate_alpha_power_from_raw,
-    SpectralEntropyResult,
-    calculate_spectral_entropy,
-    calculate_spectral_entropy_time_series,
-    PsdPeaksResult,
+    AlphaPowerResult,
+    FrontalAsymmetryResult,
+    FrontalThetaResult,
     HarmonicsResult,  # 後方互換性
     PeakInfo,
     PeakType,
-    analyze_psd_peaks,
-    analyze_harmonics,  # 後方互換性
-    DETAILED_FREQ_BANDS,
+    PsdPeaksResult,
     SMRResult,
+    SpectralEntropyResult,
+    analyze_harmonics,  # 後方互換性
+    analyze_psd_peaks,
+    calculate_alpha_power,
+    calculate_alpha_power_from_raw,
+    calculate_amplitude_statistics,
+    calculate_band_statistics,
+    calculate_frontal_asymmetry,
+    calculate_frontal_theta,
+    calculate_hsi_statistics,
+    calculate_itf,
+    calculate_paf,
+    calculate_psd,
     calculate_smr,
-    SMR_BAND,
+    calculate_spectral_entropy,
+    calculate_spectral_entropy_time_series,
+    calculate_spectrogram,
+    calculate_spectrogram_all_channels,
+    detect_artifact_windows,
+    filter_eeg_quality,
+    get_psd_peak_frequencies,
+    prepare_mne_raw,
+    summarize_artifacts,
 )
-
-from .segment_analysis import (
-    SegmentAnalysisResult,
-    calculate_segment_analysis,
-    MEDITATION_SCORE_WEIGHTS,
-    calculate_meditation_score,
-    calculate_best_metrics,
+from .sensors.fnirs import analyze_fnirs, calculate_hbo_hbr
+from .sensors.imu import (
+    MOTION_THRESHOLDS,
+    analyze_motion,
 )
-
 from .session_summary import (
     SessionSummaryResult,
-    generate_session_summary,
     extract_metric_value,
+    generate_session_summary,
 )
-
 
 __all__ = [
     # loaders

--- a/lib/loaders/__init__.py
+++ b/lib/loaders/__init__.py
@@ -6,25 +6,17 @@
 from .base import (
     add_timestamp_column,
     apply_warmup,
-    normalize_dataframe,
     merge_multimodal_data,
+    normalize_dataframe,
     resample_to_common_timebase,
 )
-
-from .mind_monitor import (
-    load_mind_monitor_csv,
-    get_eeg_data,
-    get_optics_data,
-    get_heart_rate_data,
-    get_data_summary
-)
-
+from .mind_monitor import get_data_summary, get_eeg_data, get_heart_rate_data, get_optics_data, load_mind_monitor_csv
 from .selfloops import (
-    rename_selfloops_file,
-    parse_selfloops_timestamp,
     generate_selfloops_filename,
-    load_selfloops_csv,
     get_hrv_data,
+    load_selfloops_csv,
+    parse_selfloops_timestamp,
+    rename_selfloops_file,
 )
 
 __all__ = [

--- a/lib/loaders/base.py
+++ b/lib/loaders/base.py
@@ -4,10 +4,11 @@
 全データソース（Mind Monitor, Selfloops等）で共通のユーティリティ関数
 """
 
-import pandas as pd
-import numpy as np
 from datetime import datetime
-from typing import Optional, Dict, Any
+from typing import Any, Dict, Optional
+
+import numpy as np
+import pandas as pd
 
 
 def add_timestamp_column(

--- a/lib/loaders/elite_hrv.py
+++ b/lib/loaders/elite_hrv.py
@@ -4,13 +4,14 @@ Elite HRVデータローダー
 Elite HRVアプリから出力されたRR間隔データの読み込みと処理を行う
 """
 
-import pandas as pd
-import numpy as np
 from datetime import datetime
 from pathlib import Path
-from typing import Optional, Dict, Any
+from typing import Any, Dict, Optional
 
-from .base import add_timestamp_column, apply_warmup, normalize_dataframe, clean_rr_intervals
+import numpy as np
+import pandas as pd
+
+from .base import clean_rr_intervals, normalize_dataframe
 
 
 def parse_elite_hrv_timestamp(filename: str) -> Optional[datetime]:

--- a/lib/loaders/mind_monitor.py
+++ b/lib/loaders/mind_monitor.py
@@ -5,9 +5,9 @@ Mind Monitor CSVの読み込みとデータ抽出の統合モジュール
 このモジュールはMind Monitor固有のCSVフォーマットに依存しています。
 """
 
-import pandas as pd
+
 import numpy as np
-from pathlib import Path
+import pandas as pd
 
 # EEG定数のインポート（get_eeg_data用）
 from ..sensors.eeg.constants import DEFAULT_SFREQ

--- a/lib/loaders/selfloops.py
+++ b/lib/loaders/selfloops.py
@@ -4,13 +4,13 @@ Selfloops HRVデータローダー
 Selfloopsアプリから出力されたHRVデータの読み込みと処理を行う
 """
 
-import pandas as pd
-import numpy as np
 from datetime import datetime
 from pathlib import Path
-from typing import Optional, Dict, Any
+from typing import Any, Dict, Optional
 
-from .base import add_timestamp_column, apply_warmup, normalize_dataframe, clean_rr_intervals
+import pandas as pd
+
+from .base import clean_rr_intervals, normalize_dataframe
 
 
 def parse_selfloops_timestamp(timestamp_line: str) -> Optional[datetime]:

--- a/lib/recorders/muse_osc.py
+++ b/lib/recorders/muse_osc.py
@@ -90,7 +90,10 @@ class MuseOSCRecorder:
         if count % 256 == 0:
             elapsed = (datetime.now() - self.start_time).seconds
             m, s = divmod(elapsed, 60)
-            print(f"[{m:02d}:{s:02d}] {count} samples | EEG: TP9={args[0]:.1f}, AF7={args[1]:.1f}, AF8={args[2]:.1f}, TP10={args[3]:.1f}")
+            print(
+                f"[{m:02d}:{s:02d}] {count} samples | EEG: "
+                f"TP9={args[0]:.1f}, AF7={args[1]:.1f}, AF8={args[2]:.1f}, TP10={args[3]:.1f}"
+            )
 
     def on_acc(self, address: str, *args) -> None:
         """加速度データ受信ハンドラー"""

--- a/lib/recorders/muse_osc.py
+++ b/lib/recorders/muse_osc.py
@@ -229,12 +229,12 @@ class MuseOSCRecorder:
         print()
         if self.source == 'muse_app_osc':
             print("Muse Appの設定:")
-            print(f"  - IP: このPCのIPアドレス")
+            print("  - IP: このPCのIPアドレス")
             print(f"  - Port: {port}")
-            print(f"  - Streaming Enabled: ON")
+            print("  - Streaming Enabled: ON")
         else:
             print("Mind Monitorの設定:")
-            print(f"  - OSC Stream Target IP: このPCのIPアドレス")
+            print("  - OSC Stream Target IP: このPCのIPアドレス")
             print(f"  - OSC Stream Target Port: {port}")
         print()
         print("Ctrl+C で記録終了・CSV保存")

--- a/lib/report/__init__.py
+++ b/lib/report/__init__.py
@@ -8,26 +8,23 @@
 """
 
 from .step import analysis_step
-
-from .steps_physio import (
-    analyze_fnirs,
-    analyze_motion_and_hr,
-    analyze_hrv,
-    analyze_respiration,
-)
-
 from .steps_eeg import (
-    plot_band_power_series,
-    prepare_mne_and_spectral,
     analyze_frontal_theta_step,
     analyze_smr_step,
+    plot_band_power_series,
+    prepare_mne_and_spectral,
 )
-
+from .steps_physio import (
+    analyze_fnirs,
+    analyze_hrv,
+    analyze_motion_and_hr,
+    analyze_respiration,
+)
 from .steps_summary import (
-    build_statistical_dataframe,
     analyze_segments,
-    plot_band_ratios_step,
+    build_statistical_dataframe,
     calculate_session_score,
+    plot_band_ratios_step,
     save_session_log,
 )
 

--- a/lib/report/steps_eeg.py
+++ b/lib/report/steps_eeg.py
@@ -14,30 +14,32 @@ Frontal Midline Theta・SMR を扱う。
 import pandas as pd
 
 from lib import (
-    prepare_mne_raw,
-    filter_eeg_quality,
-    calculate_psd,
-    calculate_spectrogram_all_channels,
-    calculate_paf,
-    calculate_itf,
-    get_psd_peak_frequencies,
-    calculate_frontal_theta,
-    calculate_frontal_asymmetry,
+    analyze_psd_peaks as compute_psd_peaks,
+)
+from lib import (
     calculate_alpha_power,
     calculate_alpha_power_from_raw,
+    calculate_frontal_asymmetry,
+    calculate_frontal_theta,
+    calculate_itf,
+    calculate_paf,
+    calculate_psd,
+    calculate_smr,
     calculate_spectral_entropy,
     calculate_spectral_entropy_time_series,
-    analyze_psd_peaks as compute_psd_peaks,
-    calculate_smr,
+    calculate_spectrogram_all_channels,
+    filter_eeg_quality,
+    get_psd_peak_frequencies,
+    prepare_mne_raw,
 )
 from lib.sensors.eeg.artifact import summarize_artifacts
 from lib.sensors.eeg.visualization import (
     plot_band_power_time_series,
-    plot_psd,
-    plot_spectrogram_grid,
     plot_paf,
-    plot_raw_preview,
+    plot_psd,
     plot_psd_peaks,
+    plot_raw_preview,
+    plot_spectrogram_grid,
 )
 
 from .step import analysis_step

--- a/lib/report/steps_physio.py
+++ b/lib/report/steps_physio.py
@@ -130,8 +130,9 @@ def analyze_hrv(df, img_dir, results, selfloops_data, hr_data):
         # R-R間隔の品質情報を保存
         if 'quality_stats' in hrv_data:
             results['rr_quality_stats'] = hrv_data['quality_stats']
-            print(f"  R-R間隔品質: {hrv_data['quality_stats']['quality_rate']:.1f}% "
-                  f"({hrv_data['quality_stats']['outliers_count']}/{hrv_data['quality_stats']['total_intervals']} outliers)")
+            quality_stats = hrv_data['quality_stats']
+            print(f"  R-R間隔品質: {quality_stats['quality_rate']:.1f}% "
+                  f"({quality_stats['outliers_count']}/{quality_stats['total_intervals']} outliers)")
 
         # セッション時間チェック
         total_duration = hrv_data['time'][-1] - hrv_data['time'][0]

--- a/lib/report/steps_physio.py
+++ b/lib/report/steps_physio.py
@@ -6,19 +6,23 @@ fNIRS / 動作検出+心拍数 / HRV / 呼吸の解析ステップ
 results をコピーして最後にマージしてはいけない）。
 """
 
-import pandas as pd
 import matplotlib.pyplot as plt
+import pandas as pd
 
 from lib import (
-    get_optics_data,
     analyze_fnirs as compute_fnirs,
-    get_heart_rate_data,
+)
+from lib import (
     analyze_motion as compute_motion,
 )
+from lib import (
+    get_heart_rate_data,
+    get_optics_data,
+)
 from lib.visualization import (
+    create_motion_stats_table,
     plot_fnirs_muse_style,
     plot_motion_heart_rate,
-    create_motion_stats_table,
 )
 
 from .step import analysis_step
@@ -66,10 +70,10 @@ def analyze_motion_and_hr(df, img_dir, results, selfloops_data):
     if selfloops_data and selfloops_data.exists():
         # Selfloopsデータから心拍数を取得
         print(f'Loading Selfloops HR data: {selfloops_data}')
-        from lib.loaders.selfloops import load_selfloops_csv
         # 別名で束縛する。同名でimportするとget_heart_rate_dataが関数スコープの
         # ローカル変数になり、else側（Muse経路）がUnboundLocalErrorで落ちる
         from lib.loaders.base import get_heart_rate_data as get_hr_from_ecg
+        from lib.loaders.selfloops import load_selfloops_csv
         sl_df = load_selfloops_csv(str(selfloops_data), warmup_seconds=0.0)
         hr_data = get_hr_from_ecg(sl_df)
         hr_data_source = 'Selfloops'
@@ -114,7 +118,7 @@ def analyze_hrv(df, img_dir, results, selfloops_data, hr_data):
 
     if selfloops_data and selfloops_data.exists():
         print('計算中: HRV解析（自律神経系）...')
-        from lib.loaders.selfloops import load_selfloops_csv, get_hrv_data
+        from lib.loaders.selfloops import get_hrv_data, load_selfloops_csv
         from lib.sensors.ecg.hrv import calculate_hrv_standard_set
 
         # Selfloopsファイルパスを保存（レポート表示用）
@@ -139,8 +143,8 @@ def analyze_hrv(df, img_dir, results, selfloops_data, hr_data):
             results['hrv_result'] = hrv_result  # 時系列データ用に保存
 
             print('プロット中: HRV時系列...')
-            from lib.sensors.ecg.visualization.hrv_plot import plot_hrv_time_series, plot_hrv_frequency
             from lib.sensors.ecg.analysis import analyze_hrv as compute_hrv_indices
+            from lib.sensors.ecg.visualization.hrv_plot import plot_hrv_frequency, plot_hrv_time_series
 
             hrv_img_name = 'hrv_time_series.png'
             plot_hrv_time_series(

--- a/lib/report/steps_summary.py
+++ b/lib/report/steps_summary.py
@@ -6,14 +6,14 @@ Statistical DataFrame / セグメント分析 / バンド比率 / 総合スコ�
 import os
 
 from lib import (
-    calculate_segment_analysis,
-    calculate_meditation_score,
     calculate_best_metrics,
+    calculate_meditation_score,
+    calculate_segment_analysis,
 )
-from lib.session_log import write_to_csv, write_to_google_sheets
 from lib.sensors.eeg.visualization import plot_band_ratios
-from lib.visualization import plot_segment_comparison
+from lib.session_log import write_to_csv, write_to_google_sheets
 from lib.statistical_dataframe import create_statistical_dataframe
+from lib.visualization import plot_segment_comparison
 
 from .step import analysis_step
 

--- a/lib/segment_analysis.py
+++ b/lib/segment_analysis.py
@@ -7,7 +7,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Dict, Optional
+from typing import TYPE_CHECKING, Any, Dict, Optional
 
 import numpy as np
 import pandas as pd
@@ -38,7 +38,7 @@ class SegmentAnalysisResult:
     segments: pd.DataFrame
     table: pd.DataFrame  # 後方互換性のため残す（metrics_tableと同じ内容）
     normalized: pd.DataFrame
-    metadata: Dict[str, object]
+    metadata: Dict[str, Any]
     band_power_table: pd.DataFrame  # 新規: バンドパワー詳細テーブル
     metrics_table: pd.DataFrame  # 新規: 比率と特徴指標テーブル
 
@@ -405,7 +405,7 @@ def calculate_segment_analysis(
     first_idx = all_indices[0] if all_indices else None
     last_idx = all_indices[-1] if all_indices else None
 
-    for idx, row in segment_frame.iterrows():
+    for _idx, row in segment_frame.iterrows():
         seg_idx = int(row['segment_index'])
 
         # 備考列: 最初/最後/ピークを表示
@@ -557,7 +557,7 @@ def calculate_meditation_score(
     iaf_cv: Optional[float] = None,
     hsi_quality: Optional[float] = None,
     weights: Optional[Dict[str, float]] = None,
-) -> Dict[str, object]:
+) -> Dict[str, Any]:
     """
     瞑想セッションの総合スコアを計算する。
 
@@ -716,7 +716,9 @@ def calculate_best_metrics(segment_result: SegmentAnalysisResult) -> Dict[str, f
         'fm_theta_best': scoring_segments['fmtheta_mean'].max() if 'fmtheta_mean' in scoring_segments else np.nan,
         'iaf_best': scoring_segments['iaf_mean'].max() if 'iaf_mean' in scoring_segments else np.nan,
         'alpha_best': scoring_segments['alpha_mean'].max() if 'alpha_mean' in scoring_segments else np.nan,
-        'theta_alpha_best': scoring_segments['theta_alpha_ratio'].max() if 'theta_alpha_ratio' in scoring_segments else np.nan,
+        'theta_alpha_best': (
+            scoring_segments['theta_alpha_ratio'].max() if 'theta_alpha_ratio' in scoring_segments else np.nan
+        ),
         # 低いほど良い指標 → 最小値
         'beta_best': scoring_segments['beta_mean'].min() if 'beta_mean' in scoring_segments else np.nan,
     }

--- a/lib/segment_analysis.py
+++ b/lib/segment_analysis.py
@@ -7,22 +7,16 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Dict, Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING, Dict, Optional
 
 import numpy as np
 import pandas as pd
 from scipy import stats
 
-from .sensors.eeg.frontal_theta import (
-    FrontalThetaResult,
-    calculate_frontal_theta,
-)
 from .sensors.eeg.artifact import PEAK_MAX_EXCLUDED_RATIO
-from .sensors.eeg.preprocessing import filter_eeg_quality
-from .statistical_dataframe import get_band_power_at_time, get_band_ratio_at_time
 
 if TYPE_CHECKING:
-    import mne
+    pass
 
 
 # ========================================

--- a/lib/sensors/__init__.py
+++ b/lib/sensors/__init__.py
@@ -8,41 +8,37 @@
 """
 
 # fNIRSセンサー（脳血流）
-from .fnirs import (
-    calculate_hbo_hbr,
-    analyze_fnirs
-)
-
 # EEGセンサー（脳波）
 from .eeg import (
-    FREQ_BANDS,
     DEFAULT_SFREQ,
+    FREQ_BANDS,
     calculate_band_statistics,
-    prepare_mne_raw,
-    filter_eeg_quality,
+    calculate_paf,
     calculate_psd,
     calculate_spectrogram,
-    calculate_paf,
-    get_psd_peak_frequencies
+    filter_eeg_quality,
+    get_psd_peak_frequencies,
+    prepare_mne_raw,
 )
+from .fnirs import analyze_fnirs, calculate_hbo_hbr
 
 # IMUセンサー（加速度・ジャイロ）
 from .imu import (
     # Motion detection (artifact removal)
     MOTION_THRESHOLDS,
-    compute_magnitude,
-    detect_motion,
-    compute_motion_score,
-    analyze_motion_intervals,
-    get_motion_epochs,
+    PostureAnalyzer,
     analyze_motion,
+    analyze_motion_intervals,
+    compute_magnitude,
+    compute_motion_score,
     # Posture analysis
     compute_posture_statistics,
-    PostureAnalyzer,
+    compute_rms,
+    detect_motion,
+    extract_sensor_data,
+    get_motion_epochs,
     # Common utilities
     remove_dc_offset,
-    compute_rms,
-    extract_sensor_data,
 )
 
 __all__ = [

--- a/lib/sensors/ecg/__init__.py
+++ b/lib/sensors/ecg/__init__.py
@@ -5,17 +5,17 @@ NeuroKit2を使用した心電図（ECG）データから心拍変動（HRV）�
 
 from .analysis import (
     analyze_hrv,
-    analyze_hrv_time_domain,
     analyze_hrv_frequency_domain,
     analyze_hrv_nonlinear,
+    analyze_hrv_time_domain,
 )
-from .hrv import calculate_hrv_standard_set, HRVResult
+from .hrv import HRVResult, calculate_hrv_standard_set
 from .respiration import (
-    calculate_breathing_rate,
-    analyze_breathing_hrv_correlation,
-    estimate_resonance_breathing_pace,
-    RespirationResult,
     ResonanceBreathingPaceResult,
+    RespirationResult,
+    analyze_breathing_hrv_correlation,
+    calculate_breathing_rate,
+    estimate_resonance_breathing_pace,
 )
 from .visualization import plot_hrv_time_series
 

--- a/lib/sensors/ecg/analysis.py
+++ b/lib/sensors/ecg/analysis.py
@@ -5,9 +5,10 @@ ECGデータからのHRV解析 - NeuroKit2ラッパー
 デバイス非依存の設計により、どのECGセンサーからのデータでも同じAPIで解析可能です。
 """
 
+from typing import Any, Dict
+
 import neurokit2 as nk
 import pandas as pd
-from typing import Dict, Any
 
 
 def analyze_hrv(hrv_data: Dict[str, Any], show: bool = False) -> pd.DataFrame:

--- a/lib/sensors/ecg/hrv.py
+++ b/lib/sensors/ecg/hrv.py
@@ -162,7 +162,7 @@ def calculate_hrv_standard_set(
         full_metrics['HRV_DFA_alpha2'] = dfa_alpha2
 
     except Exception as e:
-        raise ValueError(f"Failed to calculate HRV metrics: {e}")
+        raise ValueError(f"Failed to calculate HRV metrics: {e}") from e
 
     # 2. スライディングウィンドウでRMSSD・LF/HF時系列生成
     time_series = _calculate_sliding_window_hrv(
@@ -179,7 +179,6 @@ def calculate_hrv_standard_set(
     try:
         freqs, power = calculate_power_spectrum(rr_intervals, fs=4.0)
         slope_result = calculate_1f_slope(freqs, power, freq_range=(0.01, 0.4))
-        noise_type = classify_noise_type(slope_result['beta'])
 
         # LF/HF帯域のピーク周波数を計算
         lf_peak_freq = find_peak_frequency(freqs, power, freq_range=(0.04, 0.15))

--- a/lib/sensors/ecg/hrv.py
+++ b/lib/sensors/ecg/hrv.py
@@ -8,12 +8,12 @@ Selfloops ECGデータからNeuroKit2を使用して標準HRV指標セットを�
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Dict, Optional
 from datetime import datetime
+from typing import Any, Dict
 
+import neurokit2 as nk
 import numpy as np
 import pandas as pd
-import neurokit2 as nk
 from scipy import signal
 from scipy.interpolate import interp1d
 from scipy.stats import linregress

--- a/lib/sensors/ecg/respiration.py
+++ b/lib/sensors/ecg/respiration.py
@@ -10,9 +10,9 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Dict, Optional
 
+import neurokit2 as nk
 import numpy as np
 import pandas as pd
-import neurokit2 as nk
 from scipy import interpolate
 
 

--- a/lib/sensors/ecg/segment_analysis_hrv.py
+++ b/lib/sensors/ecg/segment_analysis_hrv.py
@@ -8,11 +8,11 @@ HRVデータを固定時間セグメントに分割し、各セグメントでHR
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 
+import neurokit2 as nk
 import numpy as np
 import pandas as pd
-import neurokit2 as nk
 
 
 @dataclass
@@ -184,7 +184,7 @@ def calculate_segment_hrv_analysis(
                 dfa_alpha1 = np.nan
                 dfa_alpha2 = np.nan
 
-        except Exception as e:
+        except Exception:
             # HRV計算失敗時はNaNを設定
             rmssd = np.nan
             sdnn = np.nan

--- a/lib/sensors/ecg/segment_analysis_hrv.py
+++ b/lib/sensors/ecg/segment_analysis_hrv.py
@@ -180,7 +180,7 @@ def calculate_segment_hrv_analysis(
                     order=1,
                     show=False
                 )
-            except:
+            except Exception:
                 dfa_alpha1 = np.nan
                 dfa_alpha2 = np.nan
 

--- a/lib/sensors/ecg/visualization/__init__.py
+++ b/lib/sensors/ecg/visualization/__init__.py
@@ -2,7 +2,7 @@
 ECG可視化モジュール
 """
 
-from .hrv_plot import plot_hrv_time_series, plot_hrv_frequency
+from .hrv_plot import plot_hrv_frequency, plot_hrv_time_series
 
 __all__ = [
     'plot_hrv_time_series',

--- a/lib/sensors/ecg/visualization/hrv_plot.py
+++ b/lib/sensors/ecg/visualization/hrv_plot.py
@@ -2,23 +2,17 @@
 心拍変動（HRV）可視化モジュール
 """
 
-from typing import Dict, Optional, Tuple, Union
 from pathlib import Path
+from typing import Dict, Optional, Tuple, Union
 
 import matplotlib.pyplot as plt
-from matplotlib.patches import Ellipse
 import numpy as np
 import pandas as pd
+from matplotlib.patches import Ellipse
 from scipy import signal
 
+from ....visualization.utils import apply_frequency_band_shading, format_time_axis, power_to_db, style_frequency_plot
 from ..hrv import HRVResult
-from ....visualization.utils import (
-    format_time_axis,
-    power_to_db,
-    apply_frequency_band_shading,
-    style_frequency_plot
-)
-
 
 # HRV周波数帯域定義（NeuroKit2準拠）
 HRV_FREQ_BANDS = {

--- a/lib/sensors/eeg/__init__.py
+++ b/lib/sensors/eeg/__init__.py
@@ -4,16 +4,13 @@ Muse脳波データの周波数バンド解析、PSD、PAF計算、可視化
 """
 
 # 定数
-from .constants import FREQ_BANDS, DEFAULT_SFREQ
-
-# 前処理
-from .preprocessing import prepare_mne_raw, filter_eeg_quality
-
-# 周波数解析
-from .frequency import calculate_psd, calculate_spectrogram, calculate_spectrogram_all_channels
-
-# 統計
-from .statistics import calculate_band_statistics, calculate_hsi_statistics
+# Alpha Power解析
+from .alpha_power import (
+    AlphaPowerMethod,
+    AlphaPowerResult,
+    calculate_alpha_power,
+    calculate_alpha_power_from_raw,
+)
 
 # アーチファクト検出（振幅ベース）
 from .artifact import (
@@ -22,15 +19,16 @@ from .artifact import (
     detect_artifact_windows,
     summarize_artifacts,
 )
+from .constants import DEFAULT_SFREQ, FREQ_BANDS
 
-# PAF解析
-from .paf import calculate_paf
+# 周波数解析
+from .frequency import calculate_psd, calculate_spectrogram, calculate_spectrogram_all_channels
 
-# ITF解析
-from .itf import calculate_itf
-
-# ユーティリティ
-from .utils import get_psd_peak_frequencies
+# FAA解析
+from .frontal_asymmetry import (
+    FrontalAsymmetryResult,
+    calculate_frontal_asymmetry,
+)
 
 # Fmθ解析
 from .frontal_theta import (
@@ -38,10 +36,31 @@ from .frontal_theta import (
     calculate_frontal_theta,
 )
 
-# FAA解析
-from .frontal_asymmetry import (
-    FrontalAsymmetryResult,
-    calculate_frontal_asymmetry,
+# ITF解析
+from .itf import calculate_itf
+
+# PAF解析
+from .paf import calculate_paf
+
+# 前処理
+from .preprocessing import filter_eeg_quality, prepare_mne_raw
+
+# PSDピーク解析
+from .psd_peaks import (
+    DETAILED_FREQ_BANDS,
+    HarmonicsResult,  # 後方互換性
+    PeakInfo,
+    PeakType,
+    PsdPeaksResult,
+    analyze_harmonics,  # 後方互換性
+    analyze_psd_peaks,
+)
+
+# SMR解析
+from .smr import (
+    SMR_BAND,
+    SMRResult,
+    calculate_smr,
 )
 
 # Spectral Entropy解析
@@ -51,31 +70,11 @@ from .spectral_entropy import (
     calculate_spectral_entropy_time_series,
 )
 
-# Alpha Power解析
-from .alpha_power import (
-    AlphaPowerResult,
-    AlphaPowerMethod,
-    calculate_alpha_power,
-    calculate_alpha_power_from_raw,
-)
+# 統計
+from .statistics import calculate_band_statistics, calculate_hsi_statistics
 
-# PSDピーク解析
-from .psd_peaks import (
-    PsdPeaksResult,
-    HarmonicsResult,  # 後方互換性
-    PeakInfo,
-    PeakType,
-    analyze_psd_peaks,
-    analyze_harmonics,  # 後方互換性
-    DETAILED_FREQ_BANDS,
-)
-
-# SMR解析
-from .smr import (
-    SMRResult,
-    calculate_smr,
-    SMR_BAND,
-)
+# ユーティリティ
+from .utils import get_psd_peak_frequencies
 
 __all__ = [
     # 定数

--- a/lib/sensors/eeg/__init__.py
+++ b/lib/sensors/eeg/__init__.py
@@ -93,6 +93,7 @@ __all__ = [
     'summarize_artifacts',
     'calculate_amplitude_statistics',
     'detect_artifact_windows',
+    'ARTIFACT_P2P_THRESHOLD_UV',
     # PAF解析
     'calculate_paf',
     # ITF解析

--- a/lib/sensors/eeg/_band_power_base.py
+++ b/lib/sensors/eeg/_band_power_base.py
@@ -10,12 +10,12 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Dict, Optional, Sequence, Tuple
 
-import pandas as pd
 import mne
+import pandas as pd
 
-from .preprocessing import prepare_mne_raw
 from .core.hilbert_power import calculate_channel_average_power
-from .core.statistics import calculate_half_comparison, create_statistics_dataframe, create_metadata
+from .core.statistics import calculate_half_comparison, create_metadata, create_statistics_dataframe
+from .preprocessing import prepare_mne_raw
 
 
 @dataclass

--- a/lib/sensors/eeg/_peak_frequency_base.py
+++ b/lib/sensors/eeg/_peak_frequency_base.py
@@ -61,7 +61,8 @@ def calculate_peak_frequency(
     -------
     result : dict
         {
-            'peak_by_channel': dict,  # チャネル/半球別 {label: {'Peak': float, 'CoG': float, 'Power': float, 'PSD': array}}
+            # チャネル/半球別 {label: {'Peak': float, 'CoG': float, 'Power': float, 'PSD': array}}
+            'peak_by_channel': dict,
             'individual_peak': float,  # 左右ピークの平均
             'individual_cog': float,   # 左右CoGの平均
             'individual_std': float,   # ピーク値の標準偏差

--- a/lib/sensors/eeg/_peak_frequency_base.py
+++ b/lib/sensors/eeg/_peak_frequency_base.py
@@ -5,9 +5,9 @@ PSD-based peak frequency calculation - shared logic for PAF and ITF.
 共通計算ロジックを提供します。
 """
 
-import numpy as np
-from typing import Dict, List, Tuple, Optional
+from typing import Dict, List, Tuple
 
+import numpy as np
 
 HEMISPHERE_CONFIG: Dict[str, List[str]] = {
     'Left': ['RAW_TP9', 'RAW_AF7'],

--- a/lib/sensors/eeg/artifact.py
+++ b/lib/sensors/eeg/artifact.py
@@ -12,7 +12,7 @@ PSDは窓単位で汚染されるため、それより細かい粒度で除去�
 
 from __future__ import annotations
 
-from typing import Dict, Optional
+from typing import Dict
 
 import numpy as np
 import pandas as pd

--- a/lib/sensors/eeg/artifact.py
+++ b/lib/sensors/eeg/artifact.py
@@ -12,7 +12,7 @@ PSDは窓単位で汚染されるため、それより細かい粒度で除去�
 
 from __future__ import annotations
 
-from typing import Dict
+from typing import Any, Dict
 
 import numpy as np
 import pandas as pd
@@ -175,7 +175,7 @@ def summarize_artifacts(
     channel_names: list,
     window_samples: int = ARTIFACT_WINDOW_SAMPLES,
     threshold_uv: float = ARTIFACT_P2P_THRESHOLD_UV,
-) -> Dict[str, object]:
+) -> Dict[str, Any]:
     """
     アーチファクト検出結果をまとめて返す。
 

--- a/lib/sensors/eeg/band_power.py
+++ b/lib/sensors/eeg/band_power.py
@@ -15,7 +15,7 @@ import numpy as np
 import pandas as pd
 from scipy.signal import welch
 
-from .constants import FREQ_BANDS, DEFAULT_SFREQ
+from .constants import DEFAULT_SFREQ, FREQ_BANDS
 
 # チャネル名マッピング: RAW_XX -> XX
 RAW_CHANNELS = ['TP9', 'AF7', 'AF8', 'TP10']

--- a/lib/sensors/eeg/core/hilbert_power.py
+++ b/lib/sensors/eeg/core/hilbert_power.py
@@ -12,11 +12,11 @@ MNE-Pythonを使用してバンドパスフィルタ→ヒルベルト包絡線�
 
 from __future__ import annotations
 
-from typing import List, Optional, Sequence, Tuple
+from typing import Sequence, Tuple
 
+import mne
 import numpy as np
 import pandas as pd
-import mne
 
 
 def calculate_hilbert_band_power(

--- a/lib/sensors/eeg/core/statistics.py
+++ b/lib/sensors/eeg/core/statistics.py
@@ -6,7 +6,7 @@ EEG時系列データの統計計算モジュール
 
 from __future__ import annotations
 
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Dict, List, Optional, Tuple
 
 import numpy as np
 import pandas as pd

--- a/lib/sensors/eeg/frequency.py
+++ b/lib/sensors/eeg/frequency.py
@@ -3,8 +3,9 @@
 """
 
 import warnings
-import numpy as np
+
 import mne
+import numpy as np
 from mne.time_frequency import AverageTFRArray
 
 # Warningsとログを抑制

--- a/lib/sensors/eeg/frontal_asymmetry.py
+++ b/lib/sensors/eeg/frontal_asymmetry.py
@@ -24,13 +24,12 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Optional, Tuple
 
-import numpy as np
-import pandas as pd
 import mne
+import pandas as pd
 
-from .preprocessing import prepare_mne_raw
 from .core.hilbert_power import calculate_hilbert_band_power
 from .core.statistics import calculate_half_comparison
+from .preprocessing import prepare_mne_raw
 
 
 @dataclass

--- a/lib/sensors/eeg/frontal_theta.py
+++ b/lib/sensors/eeg/frontal_theta.py
@@ -12,11 +12,11 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Dict, Iterable, Optional, Tuple
 
-import pandas as pd
 import mne
+import pandas as pd
 
-from .core.hilbert_power import calculate_channel_average_power
 from ._band_power_base import calculate_band_power
+from .core.hilbert_power import calculate_channel_average_power
 
 # 代表的なFmθ帯域プリセット（必要に応じて切り替え可能）
 FMTHETA_BAND_OPTIONS: Dict[str, Tuple[float, float]] = {

--- a/lib/sensors/eeg/itf.py
+++ b/lib/sensors/eeg/itf.py
@@ -30,7 +30,8 @@ def calculate_itf(psd_dict, theta_range=(5.0, 7.0), use_hemisphere_average=True)
     -------
     itf_dict : dict
         {
-            'ptf_by_channel': dict,  # チャネル/半球別 {channel: {'PTF': float, 'CoG': float, 'Power': float, 'PSD': array}}
+            # チャネル/半球別 {channel: {'PTF': float, 'CoG': float, 'Power': float, 'PSD': array}}
+            'ptf_by_channel': dict,
             'itf_peak': float,       # ITF Peak方式 (左右PTFの平均)
             'itf_cog': float,        # ITF CoG方式 (左右CoGの平均)
             'itf': float,            # ITF (itf_peakのエイリアス)

--- a/lib/sensors/eeg/paf.py
+++ b/lib/sensors/eeg/paf.py
@@ -25,7 +25,8 @@ def calculate_paf(psd_dict, alpha_range=(8.0, 12.0), use_hemisphere_average=True
     -------
     paf_dict : dict
         {
-            'paf_by_channel': dict,  # チャネル/半球別 {channel: {'PAF': float, 'CoG': float, 'Power': float, 'PSD': array}}
+            # チャネル/半球別 {channel: {'PAF': float, 'CoG': float, 'Power': float, 'PSD': array}}
+            'paf_by_channel': dict,
             'iaf_peak': float,       # IAF Peak方式 (左右PAFの平均)
             'iaf_cog': float,        # IAF CoG方式 (左右CoGの平均)
             'iaf': float,            # IAF (iaf_peakのエイリアス、Muse app互換)

--- a/lib/sensors/eeg/preprocessing.py
+++ b/lib/sensors/eeg/preprocessing.py
@@ -3,8 +3,9 @@ EEGデータの前処理（MNE RawArray準備）
 """
 
 import warnings
-import pandas as pd
+
 import mne
+import pandas as pd
 
 from .constants import DEFAULT_SFREQ
 

--- a/lib/sensors/eeg/psd_peaks.py
+++ b/lib/sensors/eeg/psd_peaks.py
@@ -204,7 +204,7 @@ def _classify_peaks(
 
     # FMT帯域内のピークを見つけて、最もパワーの高いものをFMTピークとする
     fmt_candidates = []
-    for freq, power, prom in zip(peak_freqs, peak_powers, prominences):
+    for freq, power, _prom in zip(peak_freqs, peak_powers, prominences):
         if fmt_band[0] <= freq < fmt_band[1]:
             fmt_candidates.append((freq, power))
 

--- a/lib/sensors/eeg/smr.py
+++ b/lib/sensors/eeg/smr.py
@@ -24,8 +24,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Dict, Iterable, Optional, Tuple
 
-import pandas as pd
 import mne
+import pandas as pd
 
 from ._band_power_base import calculate_band_power
 

--- a/lib/sensors/eeg/spectral_entropy.py
+++ b/lib/sensors/eeg/spectral_entropy.py
@@ -89,11 +89,10 @@ def calculate_spectral_entropy(
     # 周波数範囲でマスク
     freq_low, freq_high = freq_range
     freq_mask = (freqs >= freq_low) & (freqs <= freq_high)
-    freqs_selected = freqs[freq_mask]
 
     # 各チャネルのエントロピーを計算
     entropy_values = []
-    for i, ch_name in enumerate(channels):
+    for i, _ch_name in enumerate(channels):
         psd_ch = psds[i][freq_mask]
         entropy_ch = _calculate_shannon_entropy(psd_ch, normalize=normalize)
         entropy_values.append(entropy_ch)
@@ -165,7 +164,6 @@ def calculate_spectral_entropy_time_series(
     # 周波数範囲でマスク
     freq_low, freq_high = freq_range
     freq_mask = (freqs >= freq_low) & (freqs <= freq_high)
-    freqs_selected = freqs[freq_mask]
     power_selected = power[freq_mask, :]
 
     # 各時間点でのエントロピーを計算

--- a/lib/sensors/eeg/utils.py
+++ b/lib/sensors/eeg/utils.py
@@ -3,7 +3,6 @@ EEG解析ユーティリティ関数
 """
 
 import pandas as pd
-import matplotlib.pyplot as plt
 
 from .constants import FREQ_BANDS
 

--- a/lib/sensors/eeg/visualization/__init__.py
+++ b/lib/sensors/eeg/visualization/__init__.py
@@ -7,17 +7,17 @@ EEG可視化モジュール
 
 # 基本EEG可視化
 from .eeg_plots import (
-    plot_raw_preview,
     plot_band_power_time_series,
-    plot_psd,
-    plot_spectrogram,
-    plot_spectrogram_grid,
     plot_band_ratios,
     plot_paf,
+    plot_psd,
+    plot_raw_preview,
+    plot_spectrogram,
+    plot_spectrogram_grid,
 )
 
 # 指標別可視化
-from .psd_peaks_plot import plot_psd_peaks, plot_harmonics  # plot_harmonicsは後方互換性
+from .psd_peaks_plot import plot_harmonics, plot_psd_peaks  # plot_harmonicsは後方互換性
 
 __all__ = [
     # 基本EEG可視化

--- a/lib/sensors/eeg/visualization/eeg_plots.py
+++ b/lib/sensors/eeg/visualization/eeg_plots.py
@@ -2,15 +2,12 @@
 EEG基本可視化モジュール
 """
 
+import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
-import matplotlib.pyplot as plt
-import matplotlib.dates as mdates
 
+from ....visualization.utils import apply_frequency_band_shading, format_time_axis
 from ..constants import FREQ_BANDS
-from ..frequency import calculate_psd
-from ....visualization.utils import format_time_axis, apply_frequency_band_shading
-
 
 DEFAULT_SPECTROGRAM_CMAP = 'magma'
 

--- a/lib/sensors/eeg/visualization/psd_peaks_plot.py
+++ b/lib/sensors/eeg/visualization/psd_peaks_plot.py
@@ -5,11 +5,11 @@ PSDピーク分析の可視化モジュール
 from pathlib import Path
 from typing import Optional, Union
 
-import numpy as np
 import matplotlib.pyplot as plt
+import numpy as np
 
-from ..psd_peaks import PsdPeaksResult, PeakType, DETAILED_FREQ_BANDS
-from ....visualization.utils import power_to_db, style_frequency_plot
+from ....visualization.utils import power_to_db
+from ..psd_peaks import DETAILED_FREQ_BANDS, PeakType, PsdPeaksResult
 
 
 def plot_psd_peaks(

--- a/lib/sensors/fnirs.py
+++ b/lib/sensors/fnirs.py
@@ -7,7 +7,6 @@ fNIRSセンサーによる近赤外光計測データから脳血流を解析し
 
 import numpy as np
 
-
 # Modified Beer-Lambert Lawのパラメータ
 EXTINCTION_COEF = {
     730: {'HbO': 1.4866, 'HbR': 3.8437},  # 730nm

--- a/lib/sensors/imu.py
+++ b/lib/sensors/imu.py
@@ -6,10 +6,10 @@ Muse S の加速度計・ジャイロスコープを統合的に扱います。
 - 姿勢統計量：坐禅中の姿勢安定性評価用の統計量計算
 """
 
+from typing import Dict
+
 import numpy as np
 import pandas as pd
-from typing import Dict, Optional
-
 
 # ============================================================
 # 定数定義

--- a/lib/sensors/imu.py
+++ b/lib/sensors/imu.py
@@ -825,17 +825,6 @@ class PostureAnalyzer:
                 ...
             }
         """
-        # 全期間での統計量
-        acc_x = df['Accelerometer_X'].values
-        acc_y = df['Accelerometer_Y'].values
-        acc_z = df['Accelerometer_Z'].values
-        gyro_x = df['Gyro_X'].values
-        gyro_y = df['Gyro_Y'].values
-        gyro_z = df['Gyro_Z'].values
-
-        metrics = self.compute_essential(acc_x, acc_y, acc_z,
-                                        gyro_x, gyro_y, gyro_z)
-
         # 時系列での変動を計算するため、短い間隔で分析
         interval_df = self.analyze_intervals(df, interval='10s', level='essential')
 

--- a/lib/session_log.py
+++ b/lib/session_log.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
-from typing import Dict, Optional, List
+from typing import Dict, List, Optional
 
 import numpy as np
 import pandas as pd
@@ -249,7 +249,7 @@ def write_to_google_sheets(
             range=f'{sheet_name}!A:N',
         ).execute()
         values = result.get('values', [])
-    except Exception as e:
+    except Exception:
         # シートが存在しない場合はヘッダーを作成
         values = []
 

--- a/lib/session_summary.py
+++ b/lib/session_summary.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional, Dict, Any
+from typing import Any, Dict, Optional
 
 import pandas as pd
 

--- a/lib/statistical_dataframe.py
+++ b/lib/statistical_dataframe.py
@@ -404,7 +404,11 @@ def create_statistical_dataframe(
     # 低周波数: δ+θ (1-8Hz) = 深いリラックス・睡眠・深い瞑想
     # 高周波数: α+β+γ (8-50Hz) = 覚醒・認知活動・注意
     low_freq_power = 10 ** (band_powers_df['Delta'] / 10) + 10 ** (band_powers_df['Theta'] / 10)
-    high_freq_power = 10 ** (band_powers_df['Alpha'] / 10) + 10 ** (band_powers_df['Beta'] / 10) + 10 ** (band_powers_df['Gamma'] / 10)
+    high_freq_power = (
+        10 ** (band_powers_df['Alpha'] / 10)
+        + 10 ** (band_powers_df['Beta'] / 10)
+        + 10 ** (band_powers_df['Gamma'] / 10)
+    )
     ratios_dict['low_high'] = low_freq_power / high_freq_power
     ratios_dict['low_high_db'] = 10 * np.log10(ratios_dict['low_high'])
 
@@ -681,7 +685,8 @@ def create_statistical_dataframe(
                 resp_ts_indexed = resp_ts.copy()
                 resp_ts_indexed.index = session_start + pd.to_timedelta(resp_ts_indexed['Time (min)'], unit='m')
                 # ウォームアップ期間を除外
-                resp_ts_indexed = resp_ts_indexed[resp_ts_indexed.index >= session_start + pd.Timedelta(minutes=warmup_minutes)]
+                warmup_end = session_start + pd.Timedelta(minutes=warmup_minutes)
+                resp_ts_indexed = resp_ts_indexed[resp_ts_indexed.index >= warmup_end]
 
                 # セグメント別に集計（timestampsを使用）
                 resp_rows = []

--- a/lib/statistical_dataframe.py
+++ b/lib/statistical_dataframe.py
@@ -7,14 +7,12 @@ EEG解析のための統一的なバンドパワーおよび比率計算を提�
 
 from __future__ import annotations
 
-from typing import Dict, Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING, Dict, Optional
 
 import numpy as np
 import pandas as pd
 from scipy import stats
 
-# Spectral Entropy計算関数をインポート
-from .sensors.eeg.spectral_entropy import _calculate_shannon_entropy
 from .sensors.eeg.artifact import (
     ARTIFACT_P2P_THRESHOLD_UV,
     ARTIFACT_WINDOW_SAMPLES,
@@ -22,6 +20,9 @@ from .sensors.eeg.artifact import (
     detect_artifact_windows,
     segment_valid_ratio,
 )
+
+# Spectral Entropy計算関数をインポート
+from .sensors.eeg.spectral_entropy import _calculate_shannon_entropy
 
 if TYPE_CHECKING:
     import mne

--- a/lib/templates/__init__.py
+++ b/lib/templates/__init__.py
@@ -4,18 +4,18 @@
 Jinja2を使用した瞑想分析レポートの生成
 """
 
-from .renderer import MeditationReportRenderer
 from .filters import (
-    number_format,
-    format_percent,
-    format_db,
-    format_hz,
-    format_timestamp,
-    format_duration,
-    format_change,
     df_to_markdown,
+    format_change,
+    format_db,
+    format_duration,
+    format_hz,
+    format_percent,
     format_score,
+    format_timestamp,
+    number_format,
 )
+from .renderer import MeditationReportRenderer
 
 __all__ = [
     'MeditationReportRenderer',

--- a/lib/templates/filters.py
+++ b/lib/templates/filters.py
@@ -5,8 +5,9 @@ EEG/瞑想分析レポートテンプレート用のフォーマット関数を�
 """
 
 from datetime import datetime
-import pandas as pd
+
 import numpy as np
+import pandas as pd
 from jinja2 import Undefined
 
 

--- a/lib/templates/formatters.py
+++ b/lib/templates/formatters.py
@@ -5,8 +5,9 @@
 プレゼンテーション層のデータ変換ロジックを集約。
 """
 
-import pandas as pd
 from typing import Any
+
+import pandas as pd
 
 
 def format_respiratory_stats(respiration_result: Any) -> pd.DataFrame:

--- a/lib/templates/renderer.py
+++ b/lib/templates/renderer.py
@@ -4,12 +4,11 @@
 Jinja2を使用して瞑想分析Markdownレポートを生成
 """
 
+import logging
 from datetime import datetime
 from pathlib import Path
-import logging
 
 from jinja2 import Environment, FileSystemLoader, select_autoescape
-import pandas as pd
 
 from lib.templates.formatters import format_respiratory_stats
 
@@ -44,15 +43,15 @@ class MeditationReportRenderer:
     def _register_filters(self):
         """カスタムフィルタをJinja2環境に登録"""
         from .filters import (
-            number_format,
-            format_percent,
-            format_db,
-            format_hz,
-            format_timestamp,
-            format_duration,
-            format_change,
             df_to_markdown,
+            format_change,
+            format_db,
+            format_duration,
+            format_hz,
+            format_percent,
             format_score,
+            format_timestamp,
+            number_format,
         )
 
         self.env.filters['number_format'] = number_format

--- a/lib/visualization/__init__.py
+++ b/lib/visualization/__init__.py
@@ -6,13 +6,12 @@
 """
 
 # セグメント分析可視化
-from .segment_plot import plot_segment_comparison
-
 # fNIRS可視化
 from .fnirs import plot_fnirs, plot_fnirs_muse_style
 
 # 動作検出可視化
-from .motion import plot_motion_heart_rate, create_motion_stats_table
+from .motion import create_motion_stats_table, plot_motion_heart_rate
+from .segment_plot import plot_segment_comparison
 
 # 共通ユーティリティ
 from .utils import format_time_axis

--- a/lib/visualization/motion.py
+++ b/lib/visualization/motion.py
@@ -32,7 +32,6 @@ def plot_motion_heart_rate(motion_result, hr_data=None, df=None, figsize=(15, 10
     axes : np.ndarray
     """
     motion_df = motion_result['motion_df']
-    stats = motion_result['stats']
     motion_ratio = motion_result['motion_ratio']
 
     # セッション開始時刻を基準にした経過時間（秒）を計算

--- a/lib/visualization/segment_plot.py
+++ b/lib/visualization/segment_plot.py
@@ -14,7 +14,7 @@ from .utils import format_time_axis
 def plot_segment_comparison(
     result: SegmentAnalysisResult,
     img_path: Optional[str] = None,
-) -> 'matplotlib.figure.Figure':
+) -> plt.Figure:
     """
     セグメントごとの主要指標を時系列で可視化する。
 

--- a/lib/visualization/utils.py
+++ b/lib/visualization/utils.py
@@ -2,7 +2,7 @@
 可視化用共通ユーティリティ
 """
 
-from typing import Dict, Tuple, Optional
+from typing import Dict, Optional, Tuple
 
 import numpy as np
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,86 @@
+[tool.ruff]
+target-version = "py312"
+line-length = 120
+extend-exclude = ["venv", "issues", "analysis", "tmp", "data"]
+
+[tool.ruff.lint]
+# 段階導入。correctness (E/F)・import順序 (I)・bugbear (B) から始める。
+# pyupgrade (UP) は typing.List → list 等の一括更新が 200 箇所超になるため未導入。
+select = ["E", "F", "I", "B"]
+# B905: zip(strict=) の有無。長さ不一致が想定内かは呼び出し箇所ごとの判断が必要なため保留
+ignore = ["B905"]
+
+[tool.ruff.lint.per-file-ignores]
+# エントリポイントは sys.path 追加や matplotlib backend 固定を import より前に行うため E402 を許容
+"scripts/**" = ["E402"]
+"src/app/**" = ["E402"]
+
+[tool.ruff.lint.isort]
+known-first-party = ["lib", "src"]
+
+[tool.ruff.format]
+quote-style = "single"
+
+[tool.mypy]
+python_version = "3.12"
+files = ["lib", "scripts", "tests"]
+exclude = "^(venv|issues|analysis)/"
+# 科学計算ライブラリ（pandas/mne/neurokit2 等）は型スタブを持たないため無視する
+ignore_missing_imports = true
+# 段階導入。未注釈関数の本体もチェックし、明らかな誤りは拾う
+check_untyped_defs = true
+warn_redundant_casts = true
+warn_unused_ignores = true
+no_implicit_optional = true
+
+# --- mypy 既存債務（staged 導入） ---
+# 下記は型チェック導入時点で既に注釈精度の問題があったモジュール。
+# 新規コードは完全にゲートしつつ、既存分はモジュール単位で可視化して段階的に潰す。
+# 直したら該当ブロックを削除する。空になれば債務ゼロ。
+[[tool.mypy.overrides]]
+module = "lib.loaders.elite_hrv"
+disable_error_code = ["assignment", "operator"]
+
+[[tool.mypy.overrides]]
+module = "lib.recorders.muse_osc"
+disable_error_code = ["assignment", "attr-defined"]
+
+[[tool.mypy.overrides]]
+module = "lib.sensors.ecg.hrv"
+disable_error_code = ["attr-defined"]
+
+[[tool.mypy.overrides]]
+module = "lib.sensors.ecg.visualization.hrv_plot"
+disable_error_code = ["assignment"]
+
+[[tool.mypy.overrides]]
+module = "lib.sensors.eeg.artifact"
+disable_error_code = ["index"]
+
+[[tool.mypy.overrides]]
+module = ["lib.sensors.eeg.frontal_theta", "lib.sensors.eeg.smr", "lib.visualization.fnirs"]
+disable_error_code = ["arg-type"]
+
+[[tool.mypy.overrides]]
+module = "lib.sensors.eeg.spectral_entropy"
+disable_error_code = ["arg-type", "misc"]
+
+[[tool.mypy.overrides]]
+module = "lib.statistical_dataframe"
+disable_error_code = ["assignment", "operator", "var-annotated"]
+
+[[tool.mypy.overrides]]
+module = "lib.visualization.utils"
+disable_error_code = ["operator"]
+
+[[tool.mypy.overrides]]
+module = ["scripts.cleanup_old_gdrive_data", "scripts.fetch_from_gdrive", "scripts.report.generate_hrv"]
+disable_error_code = ["assignment"]
+
+[[tool.mypy.overrides]]
+module = "scripts.osc_receiver"
+disable_error_code = ["attr-defined"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-q"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,13 @@
+# 開発用ツール（本番の解析実行には不要）
+# インストール: VIRTUAL_ENV=venv uv pip install -r requirements-dev.txt
+
+-r requirements.txt
+
+# Lint / Format
+ruff>=0.16
+
+# 型チェック
+mypy>=2.3
+
+# テスト
+pytest>=8.0

--- a/scripts/analyze_025hz_peak.py
+++ b/scripts/analyze_025hz_peak.py
@@ -93,7 +93,6 @@ def main():
 
         # 実際のパワーを確認
         closest_idx = np.argmin(np.abs(freqs - harmonic_hz))
-        actual_freq = freqs[closest_idx]
         actual_power = power[closest_idx]
         rel_power = (actual_power / power[sorted_indices[0]]) * 100
 
@@ -112,7 +111,6 @@ def main():
         # 実際のパワーを確認
         if harmonic_hz <= freqs[-1]:
             closest_idx = np.argmin(np.abs(freqs - harmonic_hz))
-            actual_freq = freqs[closest_idx]
             actual_power = power[closest_idx]
             rel_power = (actual_power / power[sorted_indices[0]]) * 100
 
@@ -177,7 +175,7 @@ def main():
 
     # 主要ピークをマーク
     hf_sorted = np.argsort(power[hf_mask])[::-1][:5]
-    for i, idx in enumerate(hf_sorted):
+    for _i, idx in enumerate(hf_sorted):
         freq = freqs[hf_mask][idx]
         pwr = power[hf_mask][idx]
         ax2.axvline(freq, color='red', linestyle='--', alpha=0.5, linewidth=1)

--- a/scripts/analyze_025hz_peak.py
+++ b/scripts/analyze_025hz_peak.py
@@ -11,15 +11,15 @@
 
 import sys
 from pathlib import Path
-import numpy as np
-from scipy import signal
+
 import matplotlib.pyplot as plt
+import numpy as np
 
 # プロジェクトルートをパスに追加
 project_root = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(project_root))
 
-from lib.loaders.selfloops import load_selfloops_csv, get_hrv_data
+from lib.loaders.selfloops import get_hrv_data, load_selfloops_csv
 from lib.sensors.ecg.hrv import calculate_power_spectrum
 
 
@@ -75,11 +75,11 @@ def main():
     mean_br_hz = mean_br / 60.0
     spectral_br_hz = spectral_br / 60.0
 
-    print(f'\nレポート記載の呼吸数:')
+    print('\nレポート記載の呼吸数:')
     print(f'  Mean BR: {mean_br} bpm = {mean_br_hz:.4f} Hz')
     print(f'  Spectral BR: {spectral_br} bpm = {spectral_br_hz:.4f} Hz')
 
-    print(f'\n呼吸周波数の高調波:')
+    print('\n呼吸周波数の高調波:')
 
     # Mean BRの高調波
     print(f'\n  Mean BR ({mean_br} bpm) の高調波:')
@@ -200,7 +200,7 @@ def main():
     print('結論: 0.25 Hz ピークの原因')
     print('='*70)
 
-    print(f'''
+    print('''
 主要な要因:
   1. 基本呼吸周波数の4次高調波
      - Mean BR (3.8 bpm) × 4 = 15.2 bpm ≈ 0.253 Hz

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+#
+# Lint / 型チェック / テストをまとめて実行する
+#
+# Usage:
+#   bash scripts/check.sh          # 全部実行
+#   bash scripts/check.sh lint     # ruff のみ
+#   bash scripts/check.sh types    # mypy のみ
+#   bash scripts/check.sh test     # pytest のみ
+#   bash scripts/check.sh fix      # ruff の自動修正を適用
+#
+# 全ステージを実行し、途中で失敗しても最後まで回してから
+# まとめて失敗を報告する（1回の実行で全ての問題を把握できるようにする）。
+
+set -uo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$PROJECT_ROOT" || exit 1
+
+PY=venv/bin/python
+if [ ! -x "$PY" ]; then
+    echo "❌ venv が見つかりません: $PROJECT_ROOT/venv"
+    echo "   セットアップ: uv venv venv && VIRTUAL_ENV=venv uv pip install -r requirements-dev.txt"
+    exit 1
+fi
+
+TARGET="${1:-all}"
+FAILED=()
+
+run_stage() {
+    local name="$1"; shift
+    echo ""
+    echo "============================================================"
+    echo "  $name"
+    echo "============================================================"
+    if "$@"; then
+        echo "✓ $name OK"
+    else
+        echo "✗ $name FAILED"
+        FAILED+=("$name")
+    fi
+}
+
+case "$TARGET" in
+    fix)
+        exec $PY -m ruff check . --fix
+        ;;
+    lint)
+        run_stage "ruff (lint)" $PY -m ruff check .
+        ;;
+    types)
+        run_stage "mypy (型チェック)" $PY -m mypy
+        ;;
+    test)
+        run_stage "pytest" $PY -m pytest
+        ;;
+    all)
+        run_stage "ruff (lint)" $PY -m ruff check .
+        run_stage "mypy (型チェック)" $PY -m mypy
+        run_stage "pytest" $PY -m pytest
+        ;;
+    *)
+        echo "❌ 不明な引数: $TARGET (使えるのは all|lint|types|test|fix)"
+        exit 1
+        ;;
+esac
+
+echo ""
+echo "============================================================"
+if [ ${#FAILED[@]} -eq 0 ]; then
+    echo "✅ すべて通過"
+    exit 0
+else
+    echo "❌ 失敗: ${FAILED[*]}"
+    exit 1
+fi

--- a/scripts/cleanup_old_gdrive_data.py
+++ b/scripts/cleanup_old_gdrive_data.py
@@ -20,11 +20,10 @@ import argparse
 import os
 import sys
 from datetime import datetime, timedelta, timezone
-from typing import List, Dict, Optional
+from typing import Dict, List, Optional
 
 from google.oauth2 import service_account
 from googleapiclient.discovery import build
-
 
 # APIスコープ（削除のために書き込み権限が必要）
 SCOPES = ['https://www.googleapis.com/auth/drive']

--- a/scripts/cleanup_old_gdrive_data.py
+++ b/scripts/cleanup_old_gdrive_data.py
@@ -20,7 +20,7 @@ import argparse
 import os
 import sys
 from datetime import datetime, timedelta, timezone
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 from google.oauth2 import service_account
 from googleapiclient.discovery import build
@@ -29,7 +29,7 @@ from googleapiclient.discovery import build
 SCOPES = ['https://www.googleapis.com/auth/drive']
 
 
-def authenticate_gdrive(credentials_path: Optional[str] = None) -> any:
+def authenticate_gdrive(credentials_path: Optional[str] = None) -> Any:
     """
     Google Drive APIに認証する
 
@@ -69,7 +69,7 @@ def authenticate_gdrive(credentials_path: Optional[str] = None) -> any:
     return service
 
 
-def list_old_files(service: any, folder_id: str, days: int) -> List[Dict]:
+def list_old_files(service: Any, folder_id: str, days: int) -> List[Dict]:
     """
     指定フォルダ内の古いファイル一覧を取得
 
@@ -144,7 +144,7 @@ def display_files(files: List[Dict]):
         print()
 
 
-def create_archive_folder(service: any, parent_folder_id: str) -> str:
+def create_archive_folder(service: Any, parent_folder_id: str) -> str:
     """
     アーカイブフォルダを作成（既に存在する場合は取得）
 
@@ -194,8 +194,8 @@ def create_archive_folder(service: any, parent_folder_id: str) -> str:
     return folder_id
 
 
-def delete_files(service: any, files: List[Dict], dry_run: bool = False,
-                 move_to_archive: bool = False, parent_folder_id: str = None) -> int:
+def delete_files(service: Any, files: List[Dict], dry_run: bool = False,
+                 move_to_archive: bool = False, parent_folder_id: Optional[str] = None) -> int:
     """
     ファイルを削除またはアーカイブフォルダに移動
 

--- a/scripts/fetch_from_gdrive.py
+++ b/scripts/fetch_from_gdrive.py
@@ -19,7 +19,7 @@ import sys
 import zipfile
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 from google.oauth2 import service_account
 from googleapiclient.discovery import build
@@ -33,7 +33,7 @@ from lib.loaders.selfloops import rename_selfloops_file
 SCOPES = ['https://www.googleapis.com/auth/drive.readonly']
 
 
-def authenticate_gdrive(credentials_path: Optional[str] = None) -> any:
+def authenticate_gdrive(credentials_path: Optional[str] = None) -> Any:
     """
     Google Drive APIに認証する
 
@@ -73,7 +73,7 @@ def authenticate_gdrive(credentials_path: Optional[str] = None) -> any:
     return service
 
 
-def list_csv_files(service: any, folder_id: str) -> List[Dict]:
+def list_csv_files(service: Any, folder_id: str) -> List[Dict]:
     """
     指定フォルダ内のCSVファイル・ZIPファイル一覧を取得
 
@@ -144,7 +144,7 @@ def display_files(files: List[Dict]):
         print()
 
 
-def download_file(service: any, file_id: str, file_name: str, output_dir: str) -> str:
+def download_file(service: Any, file_id: str, file_name: str, output_dir: str) -> str:
     """
     ファイルをダウンロード
 
@@ -225,7 +225,8 @@ def extract_zip(zip_path: str, output_dir: str) -> Optional[str]:
             # 空のディレクトリを削除
             try:
                 extracted_path.parent.rmdir()
-            except:
+            except OSError:
+                # ディレクトリが空でない場合は残したままにする
                 pass
             extracted_path = final_path
 
@@ -325,6 +326,7 @@ def main():
 
         # --download: ダウンロード
         if args.download:
+            target_file: Optional[Dict]
             if args.download.lower() == 'latest':
                 # 最新ファイル
                 target_file = files[0]

--- a/scripts/fetch_from_gdrive.py
+++ b/scripts/fetch_from_gdrive.py
@@ -14,15 +14,13 @@ Google DriveからMind Monitor CSVファイルを取得するスクリプト
 """
 
 import argparse
-import json
 import os
 import sys
 import zipfile
 from datetime import datetime
 from pathlib import Path
-from typing import List, Dict, Optional
+from typing import Dict, List, Optional
 
-from google.auth.transport.requests import Request
 from google.oauth2 import service_account
 from googleapiclient.discovery import build
 from googleapiclient.http import MediaIoBaseDownload
@@ -30,7 +28,6 @@ from googleapiclient.http import MediaIoBaseDownload
 # プロジェクトルートをパスに追加
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from lib.loaders.selfloops import rename_selfloops_file
-
 
 # APIスコープ（読み取り専用）
 SCOPES = ['https://www.googleapis.com/auth/drive.readonly']
@@ -185,7 +182,7 @@ def download_file(service: any, file_id: str, file_name: str, output_dir: str) -
                 progress = int(status.progress() * 100)
                 print(f"  進捗: {progress}%", end='\r')
 
-        print(f"  進捗: 100% ✅")
+        print("  進捗: 100% ✅")
 
     print(f"✅ ダウンロード完了: {output_path}")
     return str(output_path)
@@ -363,7 +360,7 @@ def main():
             if final_path.endswith('.csv'):
                 final_path = rename_selfloops_file(final_path)
 
-            print(f"\n✅ すべての処理が完了しました")
+            print("\n✅ すべての処理が完了しました")
             print(f"ファイルパス: {final_path}")
 
     except Exception as e:

--- a/scripts/generate_report.py
+++ b/scripts/generate_report.py
@@ -9,11 +9,12 @@ Usage:
     python generate_report.py --data <CSV_PATH> [--output <REPORT_PATH>]
 """
 
+import argparse
 import sys
 from pathlib import Path
-import argparse
 
 import matplotlib
+
 # lib 側が pyplot を import する前にバックエンドを固定する
 matplotlib.use("Agg")
 
@@ -23,33 +24,31 @@ sys.path.insert(0, str(project_root))
 
 # lib モジュールから関数をインポート
 from lib import (
-    load_mind_monitor_csv,
     calculate_band_statistics,
     calculate_hsi_statistics,
     generate_session_summary,
+    load_mind_monitor_csv,
 )
-from lib.sensors.eeg.artifact import ARTIFACT_WINDOW_SAMPLES
-from lib.sensors.eeg.band_power import compute_band_powers_from_raw, needs_band_power_computation
 
 # 解析ステップ（fNIRS / 動作+心拍 / HRV / 呼吸 / EEGスペクトル / Statistical DF /
 # セグメント / 総合スコア / ログ保存）
 from lib.report import (
     analyze_fnirs,
-    analyze_motion_and_hr,
-    analyze_hrv,
-    analyze_respiration,
-    plot_band_power_series,
-    prepare_mne_and_spectral,
     analyze_frontal_theta_step,
+    analyze_hrv,
+    analyze_motion_and_hr,
+    analyze_respiration,
+    analyze_segments,
     analyze_smr_step,
     build_statistical_dataframe,
-    analyze_segments,
-    plot_band_ratios_step,
     calculate_session_score,
+    plot_band_power_series,
+    plot_band_ratios_step,
+    prepare_mne_and_spectral,
     save_session_log,
 )
-
-
+from lib.sensors.eeg.artifact import ARTIFACT_WINDOW_SAMPLES
+from lib.sensors.eeg.band_power import compute_band_powers_from_raw, needs_band_power_computation
 
 
 def generate_markdown_report(data_path, output_dir, results):

--- a/scripts/generate_report.py
+++ b/scripts/generate_report.py
@@ -258,7 +258,10 @@ def main():
         type=str,
         choices=['none', 'csv', 'sheets'],
         default='none',
-        help='セッションログの保存先: none=保存しない（デフォルト）, csv=ローカルCSV（開発用）, sheets=Google Sheets（本番用）'
+        help=(
+            'セッションログの保存先: none=保存しない（デフォルト）, '
+            'csv=ローカルCSV（開発用）, sheets=Google Sheets（本番用）'
+        )
     )
     parser.add_argument(
         '--warmup',

--- a/scripts/osc_receiver.py
+++ b/scripts/osc_receiver.py
@@ -7,10 +7,10 @@ Muse App OSC Receiver - シンプルな受信テスト用スクリプト
 3. Muse AppでOSC出力先をこのPCのIPとポート5000に設定
 """
 
-from pythonosc import dispatcher
-from pythonosc import osc_server
 import argparse
 from datetime import datetime
+
+from pythonosc import dispatcher, osc_server
 
 
 def make_handler(name):
@@ -69,7 +69,7 @@ def main():
     print(f"Listening on {args.ip}:{args.port}")
     print()
     print("Muse Appの設定:")
-    print(f"  - IP: あなたのPCのIPアドレス")
+    print("  - IP: あなたのPCのIPアドレス")
     print(f"  - Port: {args.port}")
     print()
     print("待機中... (Ctrl+C で終了)")

--- a/scripts/osc_receiver.py
+++ b/scripts/osc_receiver.py
@@ -21,13 +21,15 @@ def make_handler(name):
     return handler
 
 
+_eeg_sample_count = 0
+
+
 def eeg_handler(address, *args):
     """EEGデータ用ハンドラー（高頻度なので簡略表示）"""
-    # 10回に1回だけ表示（256Hzは多すぎる）
-    if not hasattr(eeg_handler, 'count'):
-        eeg_handler.count = 0
-    eeg_handler.count += 1
-    if eeg_handler.count % 50 == 0:
+    # 50回に1回だけ表示（256Hzは多すぎる）
+    global _eeg_sample_count
+    _eeg_sample_count += 1
+    if _eeg_sample_count % 50 == 0:
         timestamp = datetime.now().strftime("%H:%M:%S")
         print(f"[{timestamp}] EEG: TP9={args[0]:.1f}, AF7={args[1]:.1f}, AF8={args[2]:.1f}, TP10={args[3]:.1f}")
 

--- a/scripts/report/generate_1f_analysis.py
+++ b/scripts/report/generate_1f_analysis.py
@@ -12,12 +12,12 @@ Usage:
     python generate_1f_analysis.py --data <SELFLOOPS_CSV_PATH> --output <OUTPUT_DIR>
 """
 
-import sys
-from pathlib import Path
 import argparse
-import numpy as np
-import pandas as pd
+import sys
 from datetime import datetime
+from pathlib import Path
+
+import numpy as np
 from scipy import signal
 from scipy.stats import linregress
 
@@ -26,10 +26,11 @@ project_root = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(project_root))
 
 import matplotlib
+
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 
-from lib.loaders.selfloops import load_selfloops_csv, get_hrv_data
+from lib.loaders.selfloops import get_hrv_data, load_selfloops_csv
 
 
 def calculate_power_spectrum(rr_intervals, fs=4.0):
@@ -386,7 +387,7 @@ def analyze_1f_fluctuation(data_path, output_dir, warmup_seconds=60.0):
         'duration': np.sum(rr_intervals) / 1000.0  # 秒
     }
 
-    print(f'\nR-R間隔統計:')
+    print('\nR-R間隔統計:')
     print(f'  平均: {rr_stats["mean"]:.1f} ms')
     print(f'  標準偏差: {rr_stats["std"]:.1f} ms')
     print(f'  計測時間: {rr_stats["duration"]:.1f} 秒')
@@ -399,7 +400,7 @@ def analyze_1f_fluctuation(data_path, output_dir, warmup_seconds=60.0):
     print('計算中: 1/f傾き解析...')
     slope_result = calculate_1f_slope(freqs, power, freq_range=(0.01, 0.4))
 
-    print(f'\n1/f傾き解析結果:')
+    print('\n1/f傾き解析結果:')
     print(f'  傾き (Slope): {slope_result["slope"]:.3f}')
     print(f'  相関係数 (R): {slope_result["r_value"]:.3f}')
     print(f'  決定係数 (R²): {slope_result["r_value"]**2:.3f}')

--- a/scripts/report/generate_hrv.py
+++ b/scripts/report/generate_hrv.py
@@ -13,33 +13,33 @@ Usage:
     python generate_hrv.py --data <SELFLOOPS_CSV_PATH> --output <OUTPUT_DIR>
 """
 
-import sys
-from pathlib import Path
 import argparse
+import sys
 from datetime import datetime
+from pathlib import Path
 
 # プロジェクトルートをパスに追加
 project_root = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(project_root))
 
 import matplotlib
+
 matplotlib.use("Agg")
-import matplotlib.pyplot as plt
 from jinja2 import Environment, FileSystemLoader
 
-from lib.loaders.selfloops import load_selfloops_csv, get_hrv_data
 from lib.loaders.base import get_heart_rate_data
-from lib.sensors.ecg.hrv import calculate_hrv_standard_set
-from lib.sensors.ecg.segment_analysis_hrv import calculate_segment_hrv_analysis
-from lib.sensors.ecg.visualization.hrv_plot import plot_hrv_time_series, plot_hrv_frequency, plot_hrv_nonlinear
+from lib.loaders.selfloops import get_hrv_data, load_selfloops_csv
 from lib.sensors.ecg.analysis import analyze_hrv
+from lib.sensors.ecg.hrv import calculate_hrv_standard_set
 from lib.sensors.ecg.respiration import estimate_resonance_breathing_pace
+from lib.sensors.ecg.segment_analysis_hrv import calculate_segment_hrv_analysis
+from lib.sensors.ecg.visualization.hrv_plot import plot_hrv_frequency, plot_hrv_nonlinear, plot_hrv_time_series
 from lib.templates.filters import (
-    number_format,
+    df_to_markdown,
+    format_duration,
     format_percent,
     format_timestamp,
-    format_duration,
-    df_to_markdown,
+    number_format,
 )
 from lib.templates.formatters import format_respiratory_stats
 
@@ -209,7 +209,7 @@ def analyze_hrv_session(data_path, output_dir, warmup_seconds=60.0):
         bin_width=0.5
     )
 
-    print(f'\n呼吸分析結果:')
+    print('\n呼吸分析結果:')
     print(f'  平均BR: {respiration_result.breathing_rate:.1f} bpm')
     if rbp_result:
         print(f'  共鳴呼吸回数（RMSSD基準）: {rbp_result.optimal_rmssd["range"]} bpm')

--- a/scripts/report/generate_hrv.py
+++ b/scripts/report/generate_hrv.py
@@ -17,6 +17,7 @@ import argparse
 import sys
 from datetime import datetime
 from pathlib import Path
+from typing import Any, Dict
 
 # プロジェクトルートをパスに追加
 project_root = Path(__file__).resolve().parents[2]
@@ -239,7 +240,7 @@ def analyze_hrv_session(data_path, output_dir, warmup_seconds=60.0):
         results['duration_sec'] = duration_sec
 
     # ECG/HRVデータ
-    ecg = {}
+    ecg: Dict[str, Any] = {}
     ecg['hrv_img'] = hrv_img_name
     ecg['hrv_freq_img'] = hrv_freq_img_name
     ecg['hrv_nonlinear_img'] = hrv_nonlinear_img_name

--- a/scripts/validate_alpha_power_params.py
+++ b/scripts/validate_alpha_power_params.py
@@ -34,7 +34,6 @@ import argparse
 from dataclasses import dataclass
 from typing import List, Optional
 
-import numpy as np
 import pandas as pd
 from scipy import stats
 

--- a/scripts/verify_hf_peak.py
+++ b/scripts/verify_hf_peak.py
@@ -68,11 +68,11 @@ for name, freq_hz in candidates:
 
     # 判定
     if diff_spectral < 0.5:
-        print(f"  → Spectral BRとほぼ一致！ ✓✓✓")
+        print("  → Spectral BRとほぼ一致！ ✓✓✓")
     elif diff_mean < 0.5:
-        print(f"  → Mean BRとほぼ一致！ ✓")
+        print("  → Mean BRとほぼ一致！ ✓")
     else:
-        print(f"  → どの呼吸数とも一致しない ✗")
+        print("  → どの呼吸数とも一致しない ✗")
 
 # 高調波の可能性
 print("\n" + "=" * 70)

--- a/src/app/alpha_neurofeedback.py
+++ b/src/app/alpha_neurofeedback.py
@@ -402,13 +402,10 @@ class VisualFeedback:
         for name, val in zip(ch_names, hsi):
             if val <= 1:
                 symbol = '●'
-                color_code = 'G'
             elif val <= 2:
                 symbol = '◐'
-                color_code = 'Y'
             else:
                 symbol = '○'
-                color_code = 'R'
             labels.append(f"{name}:{symbol}")
         return "  ".join(labels)
 

--- a/src/app/alpha_neurofeedback.py
+++ b/src/app/alpha_neurofeedback.py
@@ -20,7 +20,6 @@ Alpha相対パワーが高い（リラックス状態）ときに音声・視覚
 from __future__ import annotations
 
 import argparse
-import array
 import collections
 import subprocess
 import sys
@@ -37,21 +36,21 @@ import numpy as np
 try:
     import matplotlib
     matplotlib.use('TkAgg')
-    import matplotlib.pyplot as plt
     import matplotlib.animation as animation
+    import matplotlib.pyplot as plt
     MATPLOTLIB_AVAILABLE = True
 except ImportError:
     MATPLOTLIB_AVAILABLE = False
 
-from pythonosc import dispatcher, osc_server
-
 # プロジェクトルートをパスに追加
 import os
+
+from pythonosc import dispatcher, osc_server
+
 _project_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 sys.path.insert(0, _project_root)
 
 from lib.sensors.eeg.alpha_power import DEFAULT_PARAMS, AlphaPowerMethod
-
 
 # --------------------------------------------------------------------------- #
 # 定数
@@ -565,7 +564,7 @@ def main() -> None:
     print(f"History:   {args.history}s")
     print()
     print("Mind Monitor settings:")
-    print(f"  Host: <your PC IP address>")
+    print("  Host: <your PC IP address>")
     print(f"  Port: {args.port}")
     print()
     print("Waiting for data... (Ctrl+C to exit)")

--- a/tests/test_artifact_rejection.py
+++ b/tests/test_artifact_rejection.py
@@ -16,12 +16,12 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from lib.sensors.eeg.artifact import (  # noqa: E402
     ARTIFACT_RELATIVE_FLOOR_UV,
     ARTIFACT_WINDOW_SAMPLES,
+    _window_p2p,
+    calculate_amplitude_statistics,
     channel_thresholds,
     detect_artifact_windows,
-    calculate_amplitude_statistics,
     segment_valid_ratio,
     summarize_artifacts,
-    _window_p2p,
 )
 
 SFREQ = 256.0

--- a/tests/test_phase3_bels_conversion.py
+++ b/tests/test_phase3_bels_conversion.py
@@ -7,9 +7,9 @@ Fmθ、FAAの計算がμV²/lnからdB (10*log10) に正しく変換されたこ
 import numpy as np
 import pandas as pd
 
-from lib.sensors.eeg.frontal_theta import calculate_frontal_theta
-from lib.sensors.eeg.frontal_asymmetry import calculate_frontal_asymmetry
 from lib.segment_analysis import calculate_meditation_score
+from lib.sensors.eeg.frontal_asymmetry import calculate_frontal_asymmetry
+from lib.sensors.eeg.frontal_theta import calculate_frontal_theta
 
 
 def test_fmtheta_bels_output():
@@ -38,7 +38,7 @@ def test_fmtheta_bels_output():
     assert result.time_series.min() > -100  # dB下限
     assert result.time_series.max() < 100   # dB上限
 
-    print(f"✓ Fmθ dB conversion test passed")
+    print("✓ Fmθ dB conversion test passed")
     print(f"  Mean: {mean_val:.2f} dB")
     print(f"  Range: {result.time_series.min():.2f} - {result.time_series.max():.2f} dB")
 
@@ -77,7 +77,7 @@ def test_faa_bels_output():
     assert result.right_power.min() > -100
     assert result.right_power.max() < 100
 
-    print(f"✓ FAA dB conversion test passed")
+    print("✓ FAA dB conversion test passed")
     print(f"  Mean FAA: {mean_faa:.2f} dB")
     print(f"  Left power range: {result.left_power.min():.2f} - {result.left_power.max():.2f} dB")
     print(f"  Right power range: {result.right_power.min():.2f} - {result.right_power.max():.2f} dB")

--- a/tests/test_phase3_bels_conversion.py
+++ b/tests/test_phase3_bels_conversion.py
@@ -109,8 +109,14 @@ def test_meditation_score_normalization():
     assert 0.4 < faa_mid['scores']['faa'] < 0.6
 
     print("✓ Meditation score normalization test passed")
-    print(f"  Fmθ normalization: {score_min['scores']['fmtheta']:.2f} / {score_mid['scores']['fmtheta']:.2f} / {score_max['scores']['fmtheta']:.2f}")
-    print(f"  FAA normalization: {faa_min['scores']['faa']:.2f} / {faa_mid['scores']['faa']:.2f} / {faa_max['scores']['faa']:.2f}")
+    print(
+        f"  Fmθ normalization: {score_min['scores']['fmtheta']:.2f} / "
+        f"{score_mid['scores']['fmtheta']:.2f} / {score_max['scores']['fmtheta']:.2f}"
+    )
+    print(
+        f"  FAA normalization: {faa_min['scores']['faa']:.2f} / "
+        f"{faa_mid['scores']['faa']:.2f} / {faa_max['scores']['faa']:.2f}"
+    )
 
 
 def test_bels_conversion_consistency():
@@ -140,7 +146,7 @@ def test_bels_conversion_consistency():
     assert np.isclose(bels_diff, 3.01, atol=0.01)
 
     print("✓ Bels conversion consistency test passed")
-    for uv2, expected_bels in test_cases:
+    for uv2, _expected_bels in test_cases:
         print(f"  10*log10({uv2}) = {10 * np.log10(uv2):.2f} Bels")
 
 

--- a/tests/test_statistical_dataframe_iaf.py
+++ b/tests/test_statistical_dataframe_iaf.py
@@ -3,14 +3,16 @@ Statistical DataFrame IAF統合のテスト
 
 Phase 2でIAF計算がstatistical_dataframe.pyに統合されたことを確認するテスト
 """
-import pytest
+from pathlib import Path
+
 import numpy as np
 import pandas as pd
-from pathlib import Path
+import pytest
+
+from lib import load_mind_monitor_csv, prepare_mne_raw
 
 # テスト対象モジュール
 from lib.statistical_dataframe import create_statistical_dataframe
-from lib import prepare_mne_raw, load_mind_monitor_csv
 
 
 class TestStatisticalDataframeIAF:


### PR DESCRIPTION
型チェック・lint が未導入だったため、`bash scripts/check.sh` で ruff / mypy / pytest をまとめて回せるようにする。導入過程で検出された実バグも併せて修正した。

**3コミットに分けている。レビューは 3コミット目 (24ファイル / +71 -62) を見れば足りる。** 2コミット目は `ruff --fix` の自動生成で手を入れていない。

| # | commit | 内容 | 規模 |
|:--|:---|:---|:---|
| 1 | `chore:` | pyproject.toml / requirements-dev.txt / scripts/check.sh | 3ファイル（新規） |
| 2 | `style:` | `ruff check . --fix` の自動修正のみ | 60ファイル / +292 -333 |
| 3 | `fix:` | 実バグ・dead code・型注釈の修正 | 24ファイル / +71 -62 |

## 設定方針

**ruff**: line-length 120（既存コードの超過は7行だけだった）、rule set は `E, F, I, B`。

- `scripts/**`・`src/app/**` は E402 を許容 — sys.path 追加と `matplotlib.use("Agg")` を import 前に実行する意図的なパターンのため
- **B905（`zip(strict=)` 未指定、9箇所）は保留** — `strict=True`/`False` のどちらが正しいかは各呼び出しで長さ不一致が想定内かの判断が必要で、機械的に決められない
- **UP (pyupgrade) は未導入** — `typing.List` → `list`、`Optional[X]` → `X | None` の一括更新が225箇所になり、check環境整備とは別の refactor になる

**mypy**: `check_untyped_defs = true`、`ignore_missing_imports = true`（pandas/mne/neurokit2 に型スタブが無い）。

**既存の注釈債務は11モジュールの per-module override に退避した**（解消済みではない）。新規コードは完全にゲートされ、既存分だけがモジュール単位で可視化される staged 導入。直したらブロックを削除し、空になれば債務ゼロ。内容は概ね「`list[float]` と注釈されているが実体は `np.ndarray`」「Optional を返す関数の戻り値を非Optional変数に代入」といった注釈精度の問題。

うち2件は潜在バグ寄りなので**未修正のまま挙げておく**:

- `lib/sensors/eeg/spectral_entropy.py:90,165` — `freq_range: Optional[...] = (1.0, 40.0)` に対し `freq_low, freq_high = freq_range` とアンパックしており、明示的に `None` を渡すと TypeError
- `lib/recorders/muse_osc.py:246` — `self.server = None` 初期化後に `serve_forever()` を呼ぶ経路があり、セットアップ前呼び出しで AttributeError

## 検出した実バグ（commit 3）

- **`lib/visualization/segment_plot.py:17`** — 戻り値注釈が `'matplotlib.figure.Figure'` だが `import matplotlib.pyplot as plt` は `matplotlib` 名を束縛しないため未定義。`get_type_hints()` 呼び出しで NameError になる潜在バグ（ruff F821 / mypy name-defined の両方が検出）
- **`scripts/fetch_from_gdrive.py`, `scripts/cleanup_old_gdrive_data.py`（6箇所）** — 型注釈に組み込み関数 `any` を使用（`service: any`、`-> any`）。`Any` の typo
- **`scripts/cleanup_old_gdrive_data.py:198`** — `parent_folder_id: str = None` の implicit Optional
- **`lib/sensors/ecg/hrv.py:165`** — `raise ValueError(...) from e` が無く元の例外情報が失われていた
- **bare `except:` 2箇所** — `except Exception` / `except OSError` に

dead code も削除（未使用ローカル変数7件、未使用ループ変数5件）。`lib/sensors/imu.py` の `compute_essential()` 呼び出しは戻り値を捨てていたもので、#26 で削除した `PostureAnalyzer.compute_summary()` と同じパターン。`self` への代入が無いことを確認してから削除した。

## 既知の未対応

`src/app/alpha_neurofeedback.py` が588行で `check-file-size.sh` hook の500行上限を超えている。本PRの変更（3行削除）が原因ではなく既存の状態。分割は未対応。

`venv/bin/activate.fish` が `bad floating point constant` で壊れていて使えない（これも既存）。venv は uv 管理で pip が無いため、インストールは `VIRTUAL_ENV=venv uv pip install -r requirements-dev.txt`。

## Test plan

\`\`\`
$ bash scripts/check.sh
============================================================
  ruff (lint)
============================================================
All checks passed!
✓ ruff (lint) OK
============================================================
  mypy (型チェック)
============================================================
Success: no issues found in 74 source files
✓ mypy (型チェック) OK
============================================================
  pytest
============================================================
..................ssssssssss                                             [100%]
18 passed, 10 skipped in 4.41s
✓ pytest OK
============================================================
✅ すべて通過
\`\`\`

skip 10件は `data/sample.csv` 不在によるIAFテストで、この変更とは無関係（既知）。

実データ（`mindMonitor_2026-08-07--07-37-48`）でレポート再生成し、**出力が変わっていないこと**を確認:

\`\`\`
$ bash scripts/run_analysis.sh > /dev/null 2>&1; echo "exit=$?"
exit=0

beta_alpha_ratio_mean = 0.0803596088953636
beta_theta_ratio_mean = 0.2059240719286684
theta_alpha_ratio_mean = 0.4132458496318945
faa_mean = 0.6127939495284983
session_score = 55.2617287082787
\`\`\`

commit 1〜3 を積み終えた時点のツリーハッシュが、検証済みの最終状態のツリーハッシュ (`ec3339bd4cfa36e928ebc7f577de8ce65ba2942f`) と一致することを確認済み。履歴を分割して積み直しても内容は同一。

---
🤖 Claude Code session: \`$CLAUDE_SESSION_ID\`