### PR TITLE
fix: 超低速呼吸セッションで呼吸数とLF/HF解釈が破綻する問題を修正

### DIFF
--- a/lib/report/steps_physio.py
+++ b/lib/report/steps_physio.py
@@ -182,13 +182,17 @@ def analyze_respiration(hrv_data, results):
         respiration_result = calculate_breathing_rate(
             hrv_data,
             target_fs=8.0,
-            peak_distance=8.0,
             window_minutes=3.0
         )
 
         # 結果を保存（内部処理用）
         results['respiration_result'] = respiration_result
 
-        print(f'  平均BR: {respiration_result.breathing_rate:.1f} bpm')
+        print(
+            f'  平均BR: {respiration_result.breathing_rate:.1f} bpm'
+            f' ({respiration_result.breathing_rate_method})'
+        )
+        if respiration_result.is_slow_breathing:
+            print('  注意: 呼吸が0.15Hz未満のためLF/HF比は自律神経バランスとして解釈不能')
 
     return respiration_result

--- a/lib/sensors/ecg/respiration.py
+++ b/lib/sensors/ecg/respiration.py
@@ -15,6 +15,16 @@ import numpy as np
 import pandas as pd
 from scipy import interpolate
 
+# スペクトル法で呼吸ピークを探索する周波数帯域（Hz）
+# 下限0.04Hz=2.4bpm。瞑想の超低速呼吸（4-6bpm、0.07-0.10Hz）を含む一方、
+# VLF帯のドリフト（<0.04Hz）は除外する。
+BR_SEARCH_BAND_HZ = (0.04, 0.40)
+
+# LF帯（0.04-0.15Hz）の上限。呼吸がこれを下回るとRSAがHFではなくLFに計上され、
+# LF/HF比が自律神経バランスの指標として成立しなくなる。
+LF_BAND_UPPER_HZ = 0.15
+SLOW_BREATHING_THRESHOLD_BPM = LF_BAND_UPPER_HZ * 60  # 9.0 bpm
+
 
 def calculate_respiratory_period(respiratory_rate):
     """
@@ -50,15 +60,22 @@ class RespirationResult:
     Attributes
     ----------
     breathing_rate : float
-        平均呼吸数（breaths per minute）
+        呼吸数の主推定値（bpm）。スペクトル法が有効ならその値、
+        失敗時はトラフ法にフォールバックする。
+    breathing_rate_method : str
+        breathing_rate の由来（'spectral' または 'trough'）
+    breathing_rate_trough : float
+        トラフ法による平均呼吸数（bpm）。peak_distance依存が強いため補助指標。
     breathing_rate_std : float
-        呼吸数の標準偏差
+        トラフ法による瞬時呼吸数の標準偏差
     peak_count : int
         検出された呼吸ピーク数
     trough_count : int
         検出された呼吸トラフ（谷）数
     spectral_breathing_rate : float
-        スペクトル法による呼吸数（bpm）
+        スペクトル法による呼吸数（bpm）。検出できない場合はNaN。
+    is_slow_breathing : bool
+        呼吸が0.15Hz（9bpm）を下回るか。TrueならLF/HF比は解釈不能。
     time_series : pd.DataFrame
         時系列メトリクス（Time, HR, RMSSD, LF/HF, LF Power, HF Power, BR）
     metadata : dict
@@ -66,10 +83,13 @@ class RespirationResult:
     """
 
     breathing_rate: float
+    breathing_rate_method: str
+    breathing_rate_trough: float
     breathing_rate_std: float
     peak_count: int
     trough_count: int
     spectral_breathing_rate: float
+    is_slow_breathing: bool
     time_series: pd.DataFrame
     metadata: dict
 
@@ -106,14 +126,16 @@ class ResonanceBreathingPaceResult:
 def calculate_breathing_rate(
     hrv_data: Dict[str, Any],
     target_fs: float = 8.0,
-    peak_distance: float = 8.0,
+    peak_distance: Optional[float] = None,
     window_minutes: float = 3.0,
+    edr_method: str = 'soni2019',
 ) -> RespirationResult:
     """
     ECG-Derived Respiration（EDR）法で呼吸数を計算
 
     NeuroKit2を使用してR-R間隔から呼吸成分を抽出し、呼吸数を推定します。
-    深い瞑想呼吸（4-6 bpm）に対応するため、peak_distanceを長めに設定しています。
+    主推定値はスペクトル法（EDRのPSDピーク）です。トラフ法は peak_distance の
+    設定に強く依存するため補助指標として併記します。
 
     Parameters
     ----------
@@ -126,13 +148,18 @@ def calculate_breathing_rate(
     target_fs : float
         リサンプリング周波数（Hz）
         デフォルト8.0Hz（NeuroKit2のフィルタに対応）
-    peak_distance : float
+    peak_distance : float, optional
         呼吸ピーク間の最小距離（秒）
-        デフォルト8.0秒（深い瞑想呼吸 4-6 bpmに対応）
-        一般的な呼吸には0.8秒が適切
+        Noneの場合、スペクトル推定値から呼吸周期の半分を自動設定する。
+        固定値を与えると検出可能な呼吸数に上限（60/peak_distance bpm）が
+        生じるため、通常はNoneのままにすること。
     window_minutes : float
         時系列メトリクス計算のウィンドウサイズ（分）
         デフォルト3分
+    edr_method : str
+        NeuroKit2のEDR抽出フィルタ。デフォルト'soni2019'（0-0.5Hz）。
+        'vangent2019'（0.1-0.4Hz = 6-24bpm）は瞑想の超低速呼吸を
+        通過帯域外で除去してしまうため使わないこと。
 
     Returns
     -------
@@ -169,9 +196,39 @@ def calculate_breathing_rate(
     hr_resampled = f(time_resampled)
 
     # 3. ECG-Derived Respiration（EDR）を抽出
-    edr_signal = nk.ecg_rsp(hr_resampled, sampling_rate=int(target_fs), method='vangent2019')
+    edr_signal = nk.ecg_rsp(hr_resampled, sampling_rate=int(target_fs), method=edr_method)
 
-    # 4. 呼吸信号のクリーニングとピーク検出
+    # 4. 周波数解析（スペクトル法）— 主推定値
+    # nperseg は 0.04Hz を分解できる長さが必要（2048サンプル @8Hz = 256秒 → 0.004Hz分解能）。
+    # 短すぎると超低速呼吸のピークが隣接ビンに埋もれる。
+    from scipy import signal as sp_signal
+    freqs, psd = sp_signal.welch(
+        edr_signal,
+        fs=target_fs,
+        nperseg=min(2048, len(edr_signal)),
+        scaling='density'
+    )
+
+    br_low, br_high = BR_SEARCH_BAND_HZ
+    br_mask = (freqs >= br_low) & (freqs <= br_high)
+    br_freqs = freqs[br_mask]
+    br_psd = psd[br_mask]
+
+    if len(br_psd) > 0:
+        breathing_rate_spectral = br_freqs[np.argmax(br_psd)] * 60
+    else:
+        breathing_rate_spectral = np.nan
+
+    # 5. ピーク間最小距離を決定
+    # 固定値は検出可能な呼吸数に上限を課す（8秒 → 7.5bpm以下しか測れない）。
+    # スペクトル推定値から呼吸周期の半分を取り、速い呼吸にも遅い呼吸にも追随させる。
+    if peak_distance is None:
+        if np.isfinite(breathing_rate_spectral) and breathing_rate_spectral > 0:
+            peak_distance = float(np.clip(0.5 * 60.0 / breathing_rate_spectral, 1.0, 15.0))
+        else:
+            peak_distance = 2.0
+
+    # 6. 呼吸信号のクリーニングとピーク検出
     rsp_cleaned = nk.rsp_clean(edr_signal, sampling_rate=target_fs)
     rsp_peaks_dict = nk.rsp_findpeaks(
         rsp_cleaned,
@@ -183,7 +240,6 @@ def calculate_breathing_rate(
     peaks_idx = rsp_peaks_dict['RSP_Peaks']
     troughs_idx = rsp_peaks_dict['RSP_Troughs']
 
-    # 5. 呼吸数を計算
     rsp_rate = nk.rsp_rate(
         rsp_cleaned,
         troughs=rsp_peaks_dict,
@@ -191,29 +247,16 @@ def calculate_breathing_rate(
         method='trough'
     )
 
-    mean_rate = np.nanmean(rsp_rate)
+    trough_rate = np.nanmean(rsp_rate)
     std_rate = np.nanstd(rsp_rate)
 
-    # 6. 周波数解析（スペクトル法）
-    from scipy import signal as sp_signal
-    freqs, psd = sp_signal.welch(
-        edr_signal,
-        fs=target_fs,
-        nperseg=min(256, len(edr_signal)),
-        scaling='density'
-    )
-
-    # 呼吸帯域（0.15-0.4 Hz = 9-24 bpm）でピーク検出
-    br_mask = (freqs >= 0.15) & (freqs <= 0.4)
-    br_freqs = freqs[br_mask]
-    br_psd = psd[br_mask]
-
-    if len(br_psd) > 0:
-        peak_idx = np.argmax(br_psd)
-        peak_freq = br_freqs[peak_idx]
-        breathing_rate_spectral = peak_freq * 60
+    # スペクトル法を主推定値とし、失敗時のみトラフ法へフォールバック
+    if np.isfinite(breathing_rate_spectral):
+        mean_rate = breathing_rate_spectral
+        rate_method = 'spectral'
     else:
-        breathing_rate_spectral = np.nan
+        mean_rate = trough_rate
+        rate_method = 'trough'
 
     # 7. 時系列メトリクス計算
     metrics_df = _calculate_windowed_metrics(
@@ -232,14 +275,21 @@ def calculate_breathing_rate(
         'peak_distance_seconds': peak_distance,
         'window_minutes': window_minutes,
         'resampled_samples': len(hr_resampled),
+        'edr_method': edr_method,
+        'br_search_band_hz': BR_SEARCH_BAND_HZ,
     }
 
     return RespirationResult(
         breathing_rate=mean_rate,
+        breathing_rate_method=rate_method,
+        breathing_rate_trough=trough_rate,
         breathing_rate_std=std_rate,
         peak_count=len(peaks_idx),
         trough_count=len(troughs_idx),
         spectral_breathing_rate=breathing_rate_spectral,
+        is_slow_breathing=bool(
+            np.isfinite(mean_rate) and mean_rate < SLOW_BREATHING_THRESHOLD_BPM
+        ),
         time_series=metrics_df,
         metadata=metadata
     )
@@ -424,7 +474,7 @@ def analyze_breathing_hrv_correlation(
 def estimate_resonance_breathing_pace(
     hrv_data: Dict[str, Any],
     target_fs: float = 8.0,
-    peak_distance: float = 8.0,
+    peak_distance: Optional[float] = None,
     window_minutes: float = 3.0,
     bin_width: float = 0.5
 ) -> tuple[RespirationResult, Optional[ResonanceBreathingPaceResult]]:
@@ -440,8 +490,8 @@ def estimate_resonance_breathing_pace(
         get_hrv_data()の戻り値
     target_fs : float
         リサンプリング周波数（Hz）
-    peak_distance : float
-        呼吸ピーク間の最小距離（秒）
+    peak_distance : float, optional
+        呼吸ピーク間の最小距離（秒）。Noneでスペクトル推定値から自動設定。
     window_minutes : float
         時系列メトリクス計算のウィンドウサイズ（分）
     bin_width : float

--- a/lib/templates/formatters.py
+++ b/lib/templates/formatters.py
@@ -32,6 +32,7 @@ def format_respiratory_stats(respiration_result: Any) -> pd.DataFrame:
     """
     stats = []
 
+    # 主推定値（通常はスペクトル法）を先頭に置く
     stats.append({
         'Metric': 'Mean Breathing Rate',
         'Value': respiration_result.breathing_rate,
@@ -46,19 +47,25 @@ def format_respiratory_stats(respiration_result: Any) -> pd.DataFrame:
         'Unit': 's'
     })
 
-    stats.append({
-        'Metric': 'Breathing Rate (Std)',
-        'Value': respiration_result.breathing_rate_std,
-        'Unit': 'bpm'
-    })
-
-    if hasattr(respiration_result, 'spectral_breathing_rate') and \
-       respiration_result.spectral_breathing_rate is not None:
+    if hasattr(respiration_result, 'spectral_breathing_rate'):
         stats.append({
             'Metric': 'Breathing Rate (Spectral)',
             'Value': respiration_result.spectral_breathing_rate,
             'Unit': 'bpm'
         })
+
+    if hasattr(respiration_result, 'breathing_rate_trough'):
+        stats.append({
+            'Metric': 'Breathing Rate (Trough)',
+            'Value': respiration_result.breathing_rate_trough,
+            'Unit': 'bpm'
+        })
+
+    stats.append({
+        'Metric': 'Breathing Rate (Std)',
+        'Value': respiration_result.breathing_rate_std,
+        'Unit': 'bpm'
+    })
 
     stats.append({
         'Metric': 'Peak Count',

--- a/lib/templates/renderer.py
+++ b/lib/templates/renderer.py
@@ -257,9 +257,13 @@ class MeditationReportRenderer:
 
         # 呼吸データ
         if 'respiration_result' in results:
-            ecg['respiratory_period'] = results['respiration_result']
+            resp = results['respiration_result']
+            ecg['respiratory_period'] = resp
             # 呼吸統計テーブル（標準フォーマット）
-            ecg['respiratory_stats'] = format_respiratory_stats(results['respiration_result'])
+            ecg['respiratory_stats'] = format_respiratory_stats(resp)
+            # 呼吸がLF帯に入る場合、LF/HF比は自律神経バランスとして読めない
+            ecg['breathing_rate'] = resp.breathing_rate
+            ecg['lf_hf_unreliable'] = getattr(resp, 'is_slow_breathing', False)
 
         if ecg:
             context['ecg'] = ecg

--- a/scripts/report/generate_hrv.py
+++ b/scripts/report/generate_hrv.py
@@ -205,13 +205,15 @@ def analyze_hrv_session(data_path, output_dir, warmup_seconds=60.0):
     respiration_result, rbp_result = estimate_resonance_breathing_pace(
         hrv_data,
         target_fs=8.0,
-        peak_distance=8.0,
         window_minutes=3.0,
         bin_width=0.5
     )
 
     print('\n呼吸分析結果:')
-    print(f'  平均BR: {respiration_result.breathing_rate:.1f} bpm')
+    print(
+        f'  平均BR: {respiration_result.breathing_rate:.1f} bpm'
+        f' ({respiration_result.breathing_rate_method})'
+    )
     if rbp_result:
         print(f'  共鳴呼吸回数（RMSSD基準）: {rbp_result.optimal_rmssd["range"]} bpm')
         # RMSSD最大値は存在する場合のみ表示
@@ -262,6 +264,8 @@ def analyze_hrv_session(data_path, output_dir, warmup_seconds=60.0):
     # 呼吸データ
     ecg['respiratory_stats'] = format_respiratory_stats(respiration_result)
     ecg['respiratory_period'] = respiration_result
+    ecg['breathing_rate'] = respiration_result.breathing_rate
+    ecg['lf_hf_unreliable'] = respiration_result.is_slow_breathing
 
     # 共鳴呼吸データ
     if rbp_result and hasattr(rbp_result, 'bin_statistics'):

--- a/templates/hrv_report.md.j2
+++ b/templates/hrv_report.md.j2
@@ -45,9 +45,9 @@
 {{ ecg.hrv_freq_stats|df_to_markdown(floatfmt='.4f', index=False, standardize_columns=True) }}
 
 > **周波数領域指標**: 心拍変動を周波数解析。HFは副交感神経、LFは交感神経＋副交感神経の混合を示します。
-{% if ecg.respiratory_period %}
+{% if ecg.lf_hf_unreliable %}
 >
-> **⚠️ LF/HF比の解釈について**: 呼吸数が{{ ecg.respiratory_period.breathing_rate|number_format(1) }}回/分と非常に遅いため、呼吸性変動がLF帯域（2.4-9回/分）に集中しています。この場合、LF/HF比の従来解釈（>2.5=交感神経優位）は**適用できません**。むしろ深い瞑想状態を示唆しています。
+> **⚠️ LF/HF比の解釈について**: 呼吸数が{{ ecg.breathing_rate|number_format(1) }}回/分（{{ (ecg.breathing_rate / 60)|number_format(3) }} Hz）と遅く、LF帯域（0.04-0.15 Hz = 2.4-9回/分）に入っています。呼吸性洞性不整脈がHFではなくLFに計上されるため、LF/HF比の従来解釈（>1.0=交感神経優位）は**適用できません**。LF/HFの高値は緊張ではなくslow breathingの帰結です。
 {% else %}
 >
 > **LF/HF Ratio**: 1.0未満で副交感神経優位（リラックス）、1.0以上で交感神経優位（ストレス・緊張）が示唆されます。

--- a/templates/meditation/sections/ecg_ans.md.j2
+++ b/templates/meditation/sections/ecg_ans.md.j2
@@ -8,6 +8,7 @@
 > **時系列の見方**:
 > - **RMSSD**: 副交感神経活動の指標。高いほどリラックス状態。
 > - **LF/HF Ratio**: 自律神経バランス。1.0未満は副交感神経優位（リラックス）、1.0以上は交感神経優位（緊張）。
+>   ただし呼吸が0.15Hz（9 bpm）を下回る場合はこの解釈は成立しません（下記「周波数領域解析」参照）。
 
 {% endif %}
 {% if ecg.hrv_freq_img %}
@@ -19,6 +20,13 @@
 > - **VLF (0.0-0.04 Hz)**: Very Low Frequency - 長期的な調節機構
 > - **LF (0.04-0.15 Hz)**: Low Frequency - 交感神経＋副交感神経活動（圧受容体反射）
 > - **HF (0.15-0.4 Hz)**: High Frequency - 副交感神経活動（呼吸性洞性不整脈）
+{% if ecg.lf_hf_unreliable %}>
+> **⚠️ 本セッションではLF/HF比を自律神経バランスとして解釈できません**:
+> 呼吸数 {{ ecg.breathing_rate|number_format(1) }} bpm（{{ (ecg.breathing_rate / 60)|number_format(3) }} Hz）がLF帯域に入るため、
+> 呼吸性洞性不整脈がHFではなくLFに計上され、HFが空になります。
+> LF/HFの高値は交感神経優位ではなくslow breathingの帰結です。
+> 副交感神経活動はRMSSD・SD1で評価してください。
+{% endif %}
 
 {% endif %}
 {% if ecg.hrv_time_stats is not none or ecg.hrv_freq_stats is not none or ecg.hrv_nonlinear_stats is not none %}


### PR DESCRIPTION
## 背景

呼吸 4bpm 前後（周期15-16秒）に達する瞑想セッションで、呼吸解析の各段が瞑想帯域を構造的に除外していた。

2026-08-10 のセッションで、レポートが同じ呼吸に対して 2 通りの値を出していたのが発端:

| Metric | 値 |
|:---|---:|
| Mean Breathing Rate | 4.1 bpm |
| Breathing Rate (Spectral) | 9.4 bpm |

フィルタ前の生 HR 信号を Welch にかけると、真の呼吸は **0.0625 Hz = 3.75 bpm**（周期16秒）。両方とも正しくなかった。

```
RAW HR signal (no filter)
   0.0625 Hz =  3.75 bpm   power 534.4   ← 実際の呼吸
   0.0586 Hz =  3.52 bpm   power 421.2

EDR vangent2019 (0.1-0.4Hz filter) 適用後
   0.1328 Hz =  7.97 bpm   power  44.0   ← フィルタのスカートを見ているだけ
```

## 変更内容

### 1. EDR抽出フィルタ: `vangent2019` → `soni2019`

NeuroKit2 の `vangent2019` は **0.1–0.4 Hz バンドパス = 6–24 bpm**。6bpm 未満を通過帯域外で削るため、瞑想の超低速呼吸に対して原理的に使えない。同モジュールの docstring は「深い瞑想呼吸（4-6 bpm）に対応するため」と書いており、意図と実装が矛盾していた。`soni2019`（0–0.5 Hz）へ変更し、使ってはいけない理由を docstring に明記。

### 2. スペクトル法の探索帯域: 0.15–0.4 Hz → 0.04–0.4 Hz

従来は 9 bpm 未満が検出不能。しかも `len(br_psd) > 0` が常に真なので **NaN にならず、必ず帯域内の最大値を返す**沈黙する誤り。真値がどこにあっても 9 bpm 以上の数字が出ていた。

### 3. Welch の `nperseg`: 256 → 2048

256（@8Hz = 32秒窓、分解能 0.031 Hz）では 0.0625 Hz を分解できない。帯域だけ広げても不十分だった。

### 4. スペクトル法を主推定値に格上げ

`breathing_rate_method` / `breathing_rate_trough` を `RespirationResult` に追加し、両手法をレポートに併記。

### 5. `peak_distance` の適応化

固定 8.0 秒は検出上限を 60/8 = **7.5 bpm に固定**し、通常呼吸（12–15 bpm）を必ず過小報告していた。トラフ法の BR は実質この値で決まっていた（8.0s→4.2 bpm、4.0s→8.3 bpm と倍増）。`None` 既定でスペクトル推定値から呼吸周期の半分を自動設定するよう変更。

### 6. LF/HF に呼吸数の文脈を追加

呼吸が 0.15 Hz（9 bpm）を下回ると RSA が丸ごと LF 帯（0.04–0.15 Hz）に載り HF が空になるため、LF/HF は自律神経バランスの指標として成立しない。今回のセッションは LF peak 0.0625 Hz が呼吸数と一致しており、LF/HF = 11.9 は緊張ではなく slow breathing の帰結だった。

`is_slow_breathing` フラグを追加し、該当時のみ注記を出す。あわせて `hrv_report.md.j2` の既存注記は条件が「呼吸データが存在するか」だったため、呼吸数と無関係に「非常に遅い」と断定していたのを修正。

## 検証

```
$ bash scripts/run_analysis.sh
計算中: 呼吸分析（ECG-Derived Respiration）...
  平均BR: 3.8 bpm (spectral)
  注意: 呼吸が0.15Hz未満のためLF/HF比は自律神経バランスとして解釈不能
```

| Metric | 修正前 | 修正後 |
|:---|---:|---:|
| Mean Breathing Rate | 4.1 bpm | **3.8 bpm** |
| Respiratory Period | 14.8 s | **16.0 s** |
| Breathing Rate (Spectral) | 9.4 bpm ❌ | **3.8 bpm** |
| Breathing Rate (Trough) | — | 4.3 bpm |

生 HR 信号の PSD ピーク 3.75 bpm と一致。2手法の乖離は 2.3倍 → 0.5 bpm に縮小。レポートに⚠️注記が出ることも確認済み。

```
$ bash scripts/check.sh
✓ ruff (lint) OK
✓ mypy (型チェック) OK   Success: no issues found in 74 source files
✓ pytest OK              18 passed, 10 skipped
```

## スコープ外（残課題）

`analyze_breathing_hrv_correlation` のビン範囲が `max(3.0, ...)`〜`min(10.0, ...)` にクランプされており、通常呼吸（12–15 bpm）のセッションでは全ビンが空になって `None` を返す。同じ「遅い呼吸を前提にした決め打ち」の裏返しだが、影響は `generate_hrv.py` 経路の共鳴呼吸推定のみのため本PRでは触れていない。

---
🤖 Claude Code session: `$CLAUDE_SESSION_ID`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
