### PR TITLE
feat: 呼吸追従RSAバンドとpeak-valley RSA振幅を追加

### DIFF
--- a/lib/report/steps_physio.py
+++ b/lib/report/steps_physio.py
@@ -192,7 +192,26 @@ def analyze_respiration(hrv_data, results):
             f'  平均BR: {respiration_result.breathing_rate:.1f} bpm'
             f' ({respiration_result.breathing_rate_method})'
         )
+        print(
+            f'  RSA振幅 (peak-valley): {respiration_result.rsa_amplitude_mean:.1f} ms'
+            f' ({respiration_result.rsa_cycle_count} cycles)'
+        )
         if respiration_result.is_slow_breathing:
             print('  注意: 呼吸が0.15Hz未満のためLF/HF比は自律神経バランスとして解釈不能')
+
+        # 呼吸周波数に追従するRSAバンドのパワー（固定HF帯の代替）
+        from lib.sensors.ecg.hrv import calculate_rsa_band_power
+
+        rsa_band = calculate_rsa_band_power(
+            hrv_data['rr_intervals_clean'],
+            respiration_result.breathing_rate,
+            sampling_rate=hrv_data.get('sampling_rate', 1000),
+        )
+        if rsa_band is not None:
+            results['rsa_band'] = rsa_band
+            print(
+                f'  RSAバンド: {rsa_band["band_low_hz"]:.3f}-{rsa_band["band_high_hz"]:.3f} Hz'
+                f' / {rsa_band["power"]:.1f} ms²'
+            )
 
     return respiration_result

--- a/lib/segment_analysis.py
+++ b/lib/segment_analysis.py
@@ -251,10 +251,17 @@ def calculate_segment_analysis(
         if hrv_df is not None and start in hrv_df.index:
             rmssd_mean = hrv_df.loc[start, 'rmssd_mean']
 
-        # 呼吸数を取得（オプション）
+        # 呼吸数・RSA振幅を取得（オプション）
         br_mean = np.nan
+        rsa_amp_mean = np.nan
+        edr_amp_mean = np.nan
         if respiration_df is not None and start in respiration_df.index:
-            br_mean = respiration_df.loc[start, 'br_mean']
+            if 'br_mean' in respiration_df.columns:
+                br_mean = respiration_df.loc[start, 'br_mean']
+            if 'rsa_amp_mean' in respiration_df.columns:
+                rsa_amp_mean = respiration_df.loc[start, 'rsa_amp_mean']
+            if 'edr_amp_mean' in respiration_df.columns:
+                edr_amp_mean = respiration_df.loc[start, 'edr_amp_mean']
 
         # Yaw RMS値を取得（オプション）
         yaw_rms = np.nan
@@ -335,6 +342,8 @@ def calculate_segment_analysis(
             'hr_mean': hr_mean,
             'rmssd_mean': rmssd_mean,
             'br_mean': br_mean,
+            'rsa_amp_mean': rsa_amp_mean,
+            'edr_amp_mean': edr_amp_mean,
             'yaw_rms': yaw_rms,
             'meditation_score': meditation_score,
             'excluded_ratio': excluded_ratio,
@@ -453,6 +462,8 @@ def calculate_segment_analysis(
             'HR': row['hr_mean'],
             'HRV': row['rmssd_mean'],
             'RP (s)': 60 / row['br_mean'] if pd.notna(row['br_mean']) and row['br_mean'] > 0 else None,
+            'RSA (ms)': row['rsa_amp_mean'],
+            'EDR amp': row['edr_amp_mean'],
             'Yaw RMS': row['yaw_rms'],
             '除外 (%)': row['excluded_ratio'] * 100 if pd.notna(row['excluded_ratio']) else None,
             '備考': note,

--- a/lib/sensors/ecg/hrv.py
+++ b/lib/sensors/ecg/hrv.py
@@ -514,6 +514,84 @@ def _interpret_hrv_metric(metric_name: str, value: float) -> str:
     return '-'
 
 
+
+# RSAバンド（呼吸追従帯域）の半値幅。呼吸周波数 f0 に対し相対幅を基本とし、
+# 超低速呼吸で幅が潰れないよう絶対下限を設ける。
+RSA_BAND_REL_HALF_WIDTH = 0.25
+RSA_BAND_MIN_HALF_WIDTH_HZ = 0.02
+RSA_BAND_FLOOR_HZ = 0.003
+
+
+def calculate_rsa_band_power(
+    rr_intervals: np.ndarray,
+    breathing_rate_bpm: float,
+    sampling_rate: int = 1000,
+) -> dict | None:
+    """
+    呼吸周波数に追従するRSAバンドのパワーを計算
+
+    固定のHF帯（0.15-0.4Hz）は「人は12-24回/分で呼吸する」前提で作られており、
+    瞑想の超低速呼吸ではRSAがHFではなくLF帯に落ちて、HF・LF/HF比が意味を失う。
+    呼吸周波数 f0 を中心にバンドを切り直すことで、呼吸数によらず同じ構成概念
+    （呼吸性洞性不整脈の大きさ）を測る。
+
+    バンド幅は f0 に対する相対幅（±25%）を基本とし、超低速呼吸で幅が潰れない
+    よう絶対下限（±0.02Hz）を設ける。
+
+    Parameters
+    ----------
+    rr_intervals : np.ndarray
+        R-R間隔（ms）
+    breathing_rate_bpm : float
+        呼吸数（bpm）。RespirationResult.breathing_rate を渡す。
+    sampling_rate : int
+        R-R間隔の元となるサンプリングレート（Hz）
+
+    Returns
+    -------
+    dict or None
+        - center_hz: バンド中心 = 呼吸周波数（Hz）
+        - band_low_hz / band_high_hz: バンド境界（Hz）
+        - power: バンドパワー（ms²）
+        呼吸数が無効な場合や計算に失敗した場合はNone。
+
+    Notes
+    -----
+    パワーは nk.hrv_frequency の ``lf`` スロットにRSAバンドを差し込んで得る。
+    これは統計テーブルのVLF/LF/HF/TPと同一のPSD推定・同一スケール（normalize=False）
+    になるため、「LFのうち何割がRSAバンドか」をそのまま比較できる。
+    この呼び出しの戻り値のうち HRV_LF 以外（TP等）は帯域が標準と異なるため使わない。
+    """
+    if not np.isfinite(breathing_rate_bpm) or breathing_rate_bpm <= 0:
+        return None
+
+    center_hz = breathing_rate_bpm / 60.0
+    half_width = max(RSA_BAND_REL_HALF_WIDTH * center_hz, RSA_BAND_MIN_HALF_WIDTH_HZ)
+    band_low = max(center_hz - half_width, RSA_BAND_FLOOR_HZ)
+    band_high = center_hz + half_width
+
+    try:
+        peaks = nk.intervals_to_peaks(rr_intervals, sampling_rate=sampling_rate)
+        metrics = nk.hrv_frequency(
+            peaks,
+            sampling_rate=sampling_rate,
+            show=False,
+            normalize=False,
+            lf=(band_low, band_high),
+        )
+        power = float(metrics['HRV_LF'].iloc[0])
+    except Exception as e:
+        print(f'⚠️  RSAバンドパワーの計算に失敗: {e}')
+        return None
+
+    return {
+        'center_hz': center_hz,
+        'band_low_hz': band_low,
+        'band_high_hz': band_high,
+        'power': power,
+    }
+
+
 def find_peak_frequency(freqs, power, freq_range):
     """
     指定周波数範囲内のピーク周波数を見つける

--- a/lib/sensors/ecg/respiration.py
+++ b/lib/sensors/ecg/respiration.py
@@ -76,6 +76,17 @@ class RespirationResult:
         スペクトル法による呼吸数（bpm）。検出できない場合はNaN。
     is_slow_breathing : bool
         呼吸が0.15Hz（9bpm）を下回るか。TrueならLF/HF比は解釈不能。
+    rsa_amplitude_mean : float
+        peak-valley法によるRSA振幅の平均（ms）。周波数帯域の定義に依存しないため、
+        超低速呼吸でもHF/LFの帯域境界に影響されずに副交感神経活動を評価できる。
+    rsa_amplitude_median : float
+        RSA振幅の中央値（ms）
+    rsa_amplitude_std : float
+        RSA振幅の標準偏差（ms）
+    rsa_cycle_count : int
+        RSA振幅を算出できた呼吸周期の数
+    rsa_cycles : pd.DataFrame
+        呼吸周期ごとの内訳。列: Time (min), RSA Amplitude (ms), EDR Amplitude (a.u.), Beats
     time_series : pd.DataFrame
         時系列メトリクス（Time, HR, RMSSD, LF/HF, LF Power, HF Power, BR）
     metadata : dict
@@ -90,6 +101,11 @@ class RespirationResult:
     trough_count: int
     spectral_breathing_rate: float
     is_slow_breathing: bool
+    rsa_amplitude_mean: float
+    rsa_amplitude_median: float
+    rsa_amplitude_std: float
+    rsa_cycle_count: int
+    rsa_cycles: pd.DataFrame
     time_series: pd.DataFrame
     metadata: dict
 
@@ -258,7 +274,19 @@ def calculate_breathing_rate(
         mean_rate = trough_rate
         rate_method = 'trough'
 
-    # 7. 時系列メトリクス計算
+    # 7. RSA振幅（peak-valley法）を呼吸周期ごとに算出
+    # トラフ間を1呼吸周期とみなす。帯域定義に依存しないため、超低速呼吸でも
+    # LF/HF比のように破綻せず副交感神経活動の推移を追える。
+    rsa_cycles = calculate_rsa_amplitude(
+        rr_intervals=rr_intervals,
+        rr_time_sec=time_original,
+        cycle_bounds_sec=np.asarray(troughs_idx, dtype=float) / target_fs,
+        edr_signal=rsp_cleaned,
+        edr_fs=target_fs,
+    )
+    rsa_values = rsa_cycles['RSA Amplitude (ms)'].to_numpy(dtype=float)
+
+    # 8. 時系列メトリクス計算
     metrics_df = _calculate_windowed_metrics(
         hrv_data,
         hr_resampled,
@@ -268,7 +296,7 @@ def calculate_breathing_rate(
         window_minutes
     )
 
-    # 8. メタデータ
+    # 9. メタデータ
     metadata = {
         'total_duration_minutes': rr_time[-1] / 60,
         'sampling_rate': target_fs,
@@ -290,9 +318,95 @@ def calculate_breathing_rate(
         is_slow_breathing=bool(
             np.isfinite(mean_rate) and mean_rate < SLOW_BREATHING_THRESHOLD_BPM
         ),
+        rsa_amplitude_mean=float(np.mean(rsa_values)) if len(rsa_values) else np.nan,
+        rsa_amplitude_median=float(np.median(rsa_values)) if len(rsa_values) else np.nan,
+        rsa_amplitude_std=float(np.std(rsa_values)) if len(rsa_values) else np.nan,
+        rsa_cycle_count=len(rsa_values),
+        rsa_cycles=rsa_cycles,
         time_series=metrics_df,
         metadata=metadata
     )
+
+
+def calculate_rsa_amplitude(
+    rr_intervals: np.ndarray,
+    rr_time_sec: np.ndarray,
+    cycle_bounds_sec: np.ndarray,
+    edr_signal: Optional[np.ndarray] = None,
+    edr_fs: Optional[float] = None,
+    min_beats: int = 3,
+) -> pd.DataFrame:
+    """
+    peak-valley法（Grossman）でRSA振幅を呼吸周期ごとに算出
+
+    各呼吸周期に含まれるR-R間隔の最大値と最小値の差を取る。周波数帯域の
+    定義を一切使わないため、呼吸が0.15Hz（9bpm）を下回りRSAがHF帯から
+    外れるセッションでも、通常呼吸のセッションと同じ意味で比較できる。
+
+    Parameters
+    ----------
+    rr_intervals : np.ndarray
+        R-R間隔（ms）
+    rr_time_sec : np.ndarray
+        各R-R間隔に対応する時刻（秒）。rr_intervals と同じ長さ。
+    cycle_bounds_sec : np.ndarray
+        呼吸周期の境界時刻（秒）。通常はEDRのトラフ時刻。
+        隣接する2要素が1呼吸周期を成すため、N個の境界からN-1周期が得られる。
+    edr_signal : np.ndarray, optional
+        クリーニング済みEDR信号。与えると周期ごとの振幅（呼吸の深さの代理指標）
+        も算出する。単位は任意（a.u.）でセッション内の相対推移のみ意味を持つ。
+    edr_fs : float, optional
+        edr_signal のサンプリング周波数（Hz）。edr_signal を与える場合は必須。
+    min_beats : int
+        1周期に必要な最小拍数。これ未満の周期は除外する。
+
+    Returns
+    -------
+    pd.DataFrame
+        列: Time (min), RSA Amplitude (ms), EDR Amplitude (a.u.), Beats
+        算出できる周期が無い場合は空のDataFrame。
+
+    References
+    ----------
+    - Grossman, P., van Beek, J., & Wientjes, C. (1990). A comparison of three
+      quantification methods for estimation of respiratory sinus arrhythmia.
+      Psychophysiology, 27(6), 702-714.
+    """
+    rr_intervals = np.asarray(rr_intervals, dtype=float)
+    rr_time_sec = np.asarray(rr_time_sec, dtype=float)
+    cycle_bounds_sec = np.asarray(cycle_bounds_sec, dtype=float)
+
+    if edr_signal is not None and edr_fs is None:
+        raise ValueError('edr_signal を指定する場合は edr_fs も必要です')
+
+    rows = []
+    for start, end in zip(cycle_bounds_sec[:-1], cycle_bounds_sec[1:]):
+        mask = (rr_time_sec >= start) & (rr_time_sec < end)
+        cycle_rr = rr_intervals[mask]
+        if len(cycle_rr) < min_beats:
+            continue
+
+        edr_amplitude = np.nan
+        if edr_signal is not None and edr_fs is not None:
+            i0 = int(round(start * edr_fs))
+            i1 = int(round(end * edr_fs))
+            cycle_edr = np.asarray(edr_signal, dtype=float)[i0:i1]
+            if len(cycle_edr) > 0:
+                edr_amplitude = float(np.max(cycle_edr) - np.min(cycle_edr))
+
+        rows.append({
+            'Time (min)': start / 60.0,
+            'RSA Amplitude (ms)': float(np.max(cycle_rr) - np.min(cycle_rr)),
+            'EDR Amplitude (a.u.)': edr_amplitude,
+            'Beats': len(cycle_rr),
+        })
+
+    if not rows:
+        return pd.DataFrame(
+            columns=['Time (min)', 'RSA Amplitude (ms)', 'EDR Amplitude (a.u.)', 'Beats']
+        )
+
+    return pd.DataFrame(rows)
 
 
 def _calculate_windowed_metrics(

--- a/lib/statistical_dataframe.py
+++ b/lib/statistical_dataframe.py
@@ -707,6 +707,42 @@ def create_statistical_dataframe(
         except Exception as e:
             print(f'警告: 呼吸統計量の計算に失敗しました ({e})')
 
+    # RSA振幅（peak-valley法）のセグメント別集計
+    # 呼吸周期ごとの値なので time_series とは行数が異なる。別途集計して結合する。
+    if respiration_result is not None and hasattr(respiration_result, 'rsa_cycles'):
+        try:
+            rsa_cycles = respiration_result.rsa_cycles
+            if isinstance(rsa_cycles, pd.DataFrame) and not rsa_cycles.empty:
+                rsa_indexed = rsa_cycles.copy()
+                rsa_indexed.index = session_start + pd.to_timedelta(
+                    rsa_indexed['Time (min)'], unit='m'
+                )
+                warmup_end = session_start + pd.Timedelta(minutes=warmup_minutes)
+                rsa_indexed = rsa_indexed[rsa_indexed.index >= warmup_end]
+
+                rsa_rows = []
+                for start_ts in timestamps:
+                    end_ts = start_ts + pd.Timedelta(minutes=segment_minutes)
+                    mask = (rsa_indexed.index >= start_ts) & (rsa_indexed.index < end_ts)
+                    segment_data = rsa_indexed.loc[mask]
+
+                    if len(segment_data) > 0:
+                        rsa_rows.append({
+                            'timestamp': start_ts,
+                            'rsa_amp_mean': segment_data['RSA Amplitude (ms)'].mean(),
+                            'edr_amp_mean': segment_data['EDR Amplitude (a.u.)'].mean(),
+                            'rsa_cycles': len(segment_data),
+                        })
+
+                if rsa_rows:
+                    rsa_df = pd.DataFrame(rsa_rows).set_index('timestamp')
+                    if respiration_df.empty:
+                        respiration_df = rsa_df
+                    else:
+                        respiration_df = respiration_df.join(rsa_df, how='outer')
+        except Exception as e:
+            print(f'警告: RSA振幅の計算に失敗しました ({e})')
+
     return {
         'band_powers': band_powers_df,
         'band_ratios': band_ratios_df,

--- a/lib/templates/formatters.py
+++ b/lib/templates/formatters.py
@@ -79,4 +79,26 @@ def format_respiratory_stats(respiration_result: Any) -> pd.DataFrame:
         'Unit': 'count'
     })
 
+    if getattr(respiration_result, 'rsa_cycle_count', 0):
+        stats.append({
+            'Metric': 'RSA Amplitude (peak-valley)',
+            'Value': respiration_result.rsa_amplitude_mean,
+            'Unit': 'ms'
+        })
+        stats.append({
+            'Metric': 'RSA Amplitude (median)',
+            'Value': respiration_result.rsa_amplitude_median,
+            'Unit': 'ms'
+        })
+        stats.append({
+            'Metric': 'RSA Amplitude (std)',
+            'Value': respiration_result.rsa_amplitude_std,
+            'Unit': 'ms'
+        })
+        stats.append({
+            'Metric': 'RSA Cycles',
+            'Value': respiration_result.rsa_cycle_count,
+            'Unit': 'count'
+        })
+
     return pd.DataFrame(stats)

--- a/lib/templates/renderer.py
+++ b/lib/templates/renderer.py
@@ -265,6 +265,16 @@ class MeditationReportRenderer:
             ecg['breathing_rate'] = resp.breathing_rate
             ecg['lf_hf_unreliable'] = getattr(resp, 'is_slow_breathing', False)
 
+        # RSAバンド（呼吸追従帯域）のパワー
+        if 'rsa_band' in results:
+            ecg['rsa_band'] = results['rsa_band']
+
+        # LF/HF比が解釈不能なセッションでは、値そのものを表から落とす。
+        # 警告文だけ添えても数字が残っていると読まれてしまうため。
+        if ecg.get('lf_hf_unreliable') and 'hrv_freq_stats' in ecg:
+            freq_stats = ecg['hrv_freq_stats']
+            ecg['hrv_freq_stats'] = freq_stats[freq_stats['Metric'] != 'LF/HF']
+
         if ecg:
             context['ecg'] = ecg
 

--- a/scripts/report/generate_hrv.py
+++ b/scripts/report/generate_hrv.py
@@ -31,7 +31,7 @@ from jinja2 import Environment, FileSystemLoader
 from lib.loaders.base import get_heart_rate_data
 from lib.loaders.selfloops import get_hrv_data, load_selfloops_csv
 from lib.sensors.ecg.analysis import analyze_hrv
-from lib.sensors.ecg.hrv import calculate_hrv_standard_set
+from lib.sensors.ecg.hrv import calculate_hrv_standard_set, calculate_rsa_band_power
 from lib.sensors.ecg.respiration import estimate_resonance_breathing_pace
 from lib.sensors.ecg.segment_analysis_hrv import calculate_segment_hrv_analysis
 from lib.sensors.ecg.visualization.hrv_plot import plot_hrv_frequency, plot_hrv_nonlinear, plot_hrv_time_series
@@ -266,6 +266,20 @@ def analyze_hrv_session(data_path, output_dir, warmup_seconds=60.0):
     ecg['respiratory_period'] = respiration_result
     ecg['breathing_rate'] = respiration_result.breathing_rate
     ecg['lf_hf_unreliable'] = respiration_result.is_slow_breathing
+
+    # RSAバンド（呼吸追従帯域）
+    rsa_band = calculate_rsa_band_power(
+        hrv_data['rr_intervals_clean'],
+        respiration_result.breathing_rate,
+        sampling_rate=hrv_data.get('sampling_rate', 1000),
+    )
+    if rsa_band is not None:
+        ecg['rsa_band'] = rsa_band
+
+    # LF/HF比が解釈不能なセッションでは値そのものを表から落とす
+    if ecg['lf_hf_unreliable'] and 'hrv_freq_stats' in ecg:
+        freq_stats = ecg['hrv_freq_stats']
+        ecg['hrv_freq_stats'] = freq_stats[freq_stats['Metric'] != 'LF/HF']
 
     # 共鳴呼吸データ
     if rbp_result and hasattr(rbp_result, 'bin_statistics'):

--- a/templates/meditation/sections/ecg_ans.md.j2
+++ b/templates/meditation/sections/ecg_ans.md.j2
@@ -8,7 +8,9 @@
 > **時系列の見方**:
 > - **RMSSD**: 副交感神経活動の指標。高いほどリラックス状態。
 > - **LF/HF Ratio**: 自律神経バランス。1.0未満は副交感神経優位（リラックス）、1.0以上は交感神経優位（緊張）。
->   ただし呼吸が0.15Hz（9 bpm）を下回る場合はこの解釈は成立しません（下記「周波数領域解析」参照）。
+{% if ecg.lf_hf_unreliable %}>   **本セッションでは呼吸が0.15Hz（9 bpm）を下回るため、グラフのLF/HFパネルは読まないでください**（下記「周波数領域解析」参照）。
+{% else %}>   ただし呼吸が0.15Hz（9 bpm）を下回る場合はこの解釈は成立しません（下記「周波数領域解析」参照）。
+{% endif %}
 
 {% endif %}
 {% if ecg.hrv_freq_img %}
@@ -21,11 +23,21 @@
 > - **LF (0.04-0.15 Hz)**: Low Frequency - 交感神経＋副交感神経活動（圧受容体反射）
 > - **HF (0.15-0.4 Hz)**: High Frequency - 副交感神経活動（呼吸性洞性不整脈）
 {% if ecg.lf_hf_unreliable %}>
-> **⚠️ 本セッションではLF/HF比を自律神経バランスとして解釈できません**:
+> **⚠️ 本セッションではLF/HF比を出力していません**:
 > 呼吸数 {{ ecg.breathing_rate|number_format(1) }} bpm（{{ (ecg.breathing_rate / 60)|number_format(3) }} Hz）がLF帯域に入るため、
 > 呼吸性洞性不整脈がHFではなくLFに計上され、HFが空になります。
-> LF/HFの高値は交感神経優位ではなくslow breathingの帰結です。
-> 副交感神経活動はRMSSD・SD1で評価してください。
+> この条件下でのLF/HFは交感神経優位ではなくslow breathingの帰結にすぎないため、
+> 誤読を避けるべく統計指標の表から除外しています。
+> 副交感神経活動は下記のRSAバンドパワー・RSA振幅、およびRMSSD・SD1で評価してください。
+{% endif %}
+{% if ecg.rsa_band %}>
+> **RSAバンド（呼吸追従帯域）**:
+> 固定のHF帯（0.15-0.4Hz）は通常呼吸（12-24 bpm）を前提とした定義のため、
+> 呼吸数によってはRSAを取りこぼします。呼吸周波数
+> {{ ecg.rsa_band.center_hz|number_format(3) }} Hz を中心に帯域を切り直すと、
+> **{{ ecg.rsa_band.band_low_hz|number_format(3) }}-{{ ecg.rsa_band.band_high_hz|number_format(3) }} Hz**
+> のパワーは **{{ ecg.rsa_band.power|number_format(1) }} ms²** です。
+> 帯域幅は呼吸周波数の±25%（下限±0.02Hz）で、呼吸数によらず同じ構成概念を測ります。
 {% endif %}
 
 {% endif %}

--- a/tests/test_rsa_metrics.py
+++ b/tests/test_rsa_metrics.py
@@ -1,0 +1,186 @@
+"""
+RSA指標（peak-valley振幅・呼吸追従バンドパワー）の真値検証
+
+既知の呼吸周波数・既知の振幅で合成したR-R間隔を使い、
+実装が期待値を復元できるかを確認する。
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from lib.sensors.ecg.hrv import (
+    RSA_BAND_MIN_HALF_WIDTH_HZ,
+    RSA_BAND_REL_HALF_WIDTH,
+    calculate_rsa_band_power,
+)
+from lib.sensors.ecg.respiration import calculate_rsa_amplitude
+
+# 合成信号のパラメータ
+BASE_RR_MS = 900.0  # 平均R-R間隔 → 約67 bpm
+SYNTH_DURATION_SEC = 600.0
+
+
+def _synthesize_rr(breathing_hz: float, amplitude_ms: float) -> tuple[np.ndarray, np.ndarray]:
+    """
+    正弦波のRSAを載せたR-R間隔を合成
+
+    RR(t) = BASE_RR_MS + amplitude_ms * sin(2π * breathing_hz * t)
+
+    Returns
+    -------
+    rr_intervals : np.ndarray
+        R-R間隔（ms）
+    rr_time_sec : np.ndarray
+        各R-R間隔に対応する時刻（秒）
+    """
+    rr_list = []
+    time_list = []
+    t = 0.0
+    while t < SYNTH_DURATION_SEC:
+        rr = BASE_RR_MS + amplitude_ms * np.sin(2 * np.pi * breathing_hz * t)
+        t += rr / 1000.0
+        rr_list.append(rr)
+        time_list.append(t)
+    return np.array(rr_list), np.array(time_list)
+
+
+class TestRsaAmplitude:
+    """peak-valley法によるRSA振幅"""
+
+    def test_recovers_known_amplitude(self):
+        """正弦波RSAのpeak-to-peak振幅（= 2 * 片振幅）を復元できる"""
+        breathing_hz = 0.0741  # 4.45 bpm（超低速呼吸）
+        amplitude_ms = 60.0
+        rr, rr_time = _synthesize_rr(breathing_hz, amplitude_ms)
+
+        # 呼吸周期の境界（トラフ相当）を真の呼吸周波数から与える
+        period = 1.0 / breathing_hz
+        bounds = np.arange(0.75 * period, rr_time[-1], period)
+
+        cycles = calculate_rsa_amplitude(rr, rr_time, bounds)
+
+        assert len(cycles) > 5
+        measured = cycles['RSA Amplitude (ms)'].mean()
+        expected = 2 * amplitude_ms
+        # 離散的なR-R間隔でのサンプリング誤差を考慮して5%許容
+        assert measured == pytest.approx(expected, rel=0.05)
+
+    def test_scales_with_amplitude(self):
+        """振幅を倍にすればRSA振幅も倍になる"""
+        breathing_hz = 0.1
+        rr_a, t_a = _synthesize_rr(breathing_hz, 30.0)
+        rr_b, t_b = _synthesize_rr(breathing_hz, 60.0)
+
+        period = 1.0 / breathing_hz
+        bounds_a = np.arange(0.75 * period, t_a[-1], period)
+        bounds_b = np.arange(0.75 * period, t_b[-1], period)
+
+        amp_a = calculate_rsa_amplitude(rr_a, t_a, bounds_a)['RSA Amplitude (ms)'].mean()
+        amp_b = calculate_rsa_amplitude(rr_b, t_b, bounds_b)['RSA Amplitude (ms)'].mean()
+
+        assert amp_b / amp_a == pytest.approx(2.0, rel=0.05)
+
+    def test_independent_of_breathing_rate(self):
+        """
+        同じ振幅なら呼吸数が変わってもRSA振幅は変わらない
+
+        これがpeak-valley法を導入する理由。固定HF帯（0.15-0.4Hz）では
+        4bpmと12bpmで測定値が大きく食い違う。
+        """
+        amplitude_ms = 50.0
+        results = []
+        for bpm in (4.0, 6.0, 12.0):
+            breathing_hz = bpm / 60.0
+            rr, t = _synthesize_rr(breathing_hz, amplitude_ms)
+            period = 1.0 / breathing_hz
+            bounds = np.arange(0.75 * period, t[-1], period)
+            results.append(calculate_rsa_amplitude(rr, t, bounds)['RSA Amplitude (ms)'].mean())
+
+        for measured in results:
+            assert measured == pytest.approx(2 * amplitude_ms, rel=0.08)
+
+    def test_short_cycles_are_dropped(self):
+        """min_beatsに満たない周期は除外される"""
+        rr, t = _synthesize_rr(0.0741, 60.0)
+        # 1秒刻みの境界では1周期あたり1拍程度しか入らない
+        bounds = np.arange(0.0, t[-1], 1.0)
+
+        cycles = calculate_rsa_amplitude(rr, t, bounds, min_beats=3)
+
+        assert cycles.empty
+
+    def test_empty_result_has_expected_columns(self):
+        """周期が得られない場合も列構成は保たれる"""
+        rr, t = _synthesize_rr(0.0741, 60.0)
+        cycles = calculate_rsa_amplitude(rr, t, np.array([0.0]))
+
+        assert isinstance(cycles, pd.DataFrame)
+        assert list(cycles.columns) == [
+            'Time (min)', 'RSA Amplitude (ms)', 'EDR Amplitude (a.u.)', 'Beats'
+        ]
+
+    def test_edr_amplitude_requires_fs(self):
+        """edr_signalだけ渡してedr_fsを省くとエラー"""
+        rr, t = _synthesize_rr(0.0741, 60.0)
+        with pytest.raises(ValueError, match='edr_fs'):
+            calculate_rsa_amplitude(rr, t, np.array([0.0, 10.0]), edr_signal=np.zeros(100))
+
+
+class TestRsaBandPower:
+    """呼吸追従バンドのパワー"""
+
+    def test_band_follows_breathing_rate(self):
+        """バンド中心が呼吸周波数に一致し、幅が相対幅と下限のルールに従う"""
+        rr, _ = _synthesize_rr(0.0741, 60.0)
+
+        slow = calculate_rsa_band_power(rr, 4.45)
+        assert slow is not None
+        assert slow['center_hz'] == pytest.approx(4.45 / 60.0)
+        # 超低速呼吸では相対幅（0.25 * 0.074 = 0.019）より絶対下限が効く
+        half_width = (slow['band_high_hz'] - slow['band_low_hz']) / 2
+        assert half_width == pytest.approx(RSA_BAND_MIN_HALF_WIDTH_HZ)
+
+        normal = calculate_rsa_band_power(rr, 15.0)
+        assert normal is not None
+        half_width = (normal['band_high_hz'] - normal['band_low_hz']) / 2
+        assert half_width == pytest.approx(RSA_BAND_REL_HALF_WIDTH * 0.25)
+
+    def test_captures_power_at_breathing_frequency(self):
+        """呼吸周波数に合わせたバンドは、外したバンドより大きなパワーを拾う"""
+        breathing_bpm = 4.45
+        rr, _ = _synthesize_rr(breathing_bpm / 60.0, 60.0)
+
+        on_target = calculate_rsa_band_power(rr, breathing_bpm)
+        off_target = calculate_rsa_band_power(rr, 15.0)
+
+        assert on_target is not None and off_target is not None
+        assert on_target['power'] > 10 * off_target['power']
+
+    def test_scales_with_amplitude(self):
+        """RSA振幅を倍にするとバンドパワーは約4倍（パワーは振幅の2乗）"""
+        breathing_bpm = 6.0
+        rr_a, _ = _synthesize_rr(breathing_bpm / 60.0, 30.0)
+        rr_b, _ = _synthesize_rr(breathing_bpm / 60.0, 60.0)
+
+        result_a = calculate_rsa_band_power(rr_a, breathing_bpm)
+        result_b = calculate_rsa_band_power(rr_b, breathing_bpm)
+
+        assert result_a is not None and result_b is not None
+        assert result_b['power'] / result_a['power'] == pytest.approx(4.0, rel=0.15)
+
+    @pytest.mark.parametrize('invalid_bpm', [np.nan, 0.0, -1.0])
+    def test_invalid_breathing_rate_returns_none(self, invalid_bpm):
+        """呼吸数が無効ならNoneを返す（呼び出し側でスキップできる）"""
+        rr, _ = _synthesize_rr(0.0741, 60.0)
+        assert calculate_rsa_band_power(rr, invalid_bpm) is None
+
+    def test_band_low_is_clipped_to_floor(self):
+        """極端に遅い呼吸でもバンド下限が0以下にならない"""
+        rr, _ = _synthesize_rr(0.0741, 60.0)
+        result = calculate_rsa_band_power(rr, 0.6)  # 0.01 Hz
+
+        assert result is not None
+        assert result['band_low_hz'] > 0


### PR DESCRIPTION
## 背景

超低速呼吸（<9bpm）のセッションでは、固定HF帯（0.15-0.4Hz）が「人は12-24回/分で呼吸する」前提の定義であるために RSA を取りこぼし、LF/HF比が自律神経バランスとして読めなくなる。#28 でこの条件を検出して警告を出すようにしたが、代替指標が無く、LF/HFの数値も表に残ったままだった。

呼吸数に依存せず副交感神経活動を読める指標を2つ追加する。

## 変更内容

### 1. 呼吸追従RSAバンド (`calculate_rsa_band_power`)

呼吸周波数 f0 を中心に帯域を切り直してパワーを算出する。帯域幅は f0 の±25%、超低速呼吸で潰れないよう絶対下限±0.02Hz。

統計テーブルのVLF/LF/HF/TPと同一のPSD推定・同一スケール（`normalize=False`）で出すため、「LFのうち何割がRSAバンドか」がそのまま比較できる。

### 2. peak-valley法によるRSA振幅 (`calculate_rsa_amplitude`)

各呼吸周期内の `max(RR) - min(RR)`（Grossman et al. 1990）。周波数帯域の定義を一切使わないため 4bpm でも 12bpm でも同じ意味で比較できる。呼吸周期の境界には既存のEDRトラフ検出結果をそのまま使うので追加の信号処理は不要。

### 3. EDR振幅（呼吸の深さの代理指標）

周期ごとのEDR振幅も併せて出し、セグメント表に載せる。

**注意**: EDRはR-R間隔から導出した信号のため、RSA振幅とは独立でない。呼吸の深さの独立した検証にはならない（真の検証には呼吸ベルト等の外部センサが要る）。

### レポート側

- LF/HF比が解釈不能なセッションでは統計指標の表から**行ごと除外**（警告文だけでは数値が読まれてしまうため）。時系列グラフ側の注記も連動
- 呼吸指標テーブルにRSA振幅（平均・中央値・SD・周期数）を追加
- セグメント表に `RSA (ms)` / `EDR amp` 列を追加

## Test plan

`tests/test_rsa_metrics.py` を新規追加（13ケース）。既知の呼吸周波数・既知の振幅で合成したR-R間隔で真値を検証する。

```
$ venv/bin/python -m pytest tests/test_rsa_metrics.py -q
.............                                                            [100%]
```

真値との突き合わせ:

| 検証 | 期待値 | 実測 |
|---|---|---|
| 正弦波RSA（片振幅60ms）のpeak-valley | 120.0 ms | 119.2 ms |
| 同振幅50msを 4 / 6 / 12 bpm で測定 | 100.0 ms | 99.4 / 98.7 / 94.7 ms |
| バンドパワーの振幅依存（×2） | ×4 | ×4.0 |
| 呼吸周波数を外したバンド（4.45→15bpm） | 大幅に低下 | 1798 → 0.034 ms² |

`bash scripts/check.sh` 全通過:

```
✓ ruff (lint) OK
✓ mypy (型チェック) OK
✓ pytest OK  (31 passed, 10 skipped)
```

実データ（2026-08-19 セッション、呼吸4.2bpm）でパイプライン全体を実行:

```
  平均BR: 4.2 bpm (spectral)
  RSA振幅 (peak-valley): 124.4 ms (86 cycles)
  RSAバンド: 0.050-0.090 Hz / 1029.0 ms²
```

生成されたセグメント表（抜粋）:

```
|   min |    HR |   HRV |   RP (s) |   RSA (ms) |   EDR amp |
|------:|------:|------:|---------:|-----------:|----------:|
|     3 | 66.91 | 37.13 |    12.53 |     162.21 |     11.42 |
|     6 | 66.00 | 34.84 |    12.76 |     155.57 |     10.27 |
|     9 | 64.53 | 32.36 |    12.59 |     121.00 |      7.67 |
|    12 | 64.27 | 31.45 |    12.44 |     100.00 |      6.64 |
|    15 | 62.52 | 26.17 |    13.59 |      95.53 |      5.75 |
```

呼吸周期（RP）がほぼ一定のまま RSA振幅が 162 → 96 ms へ低下しており、RMSSD の低下が帯域定義のアーチファクトではなく実在の現象であることが、帯域非依存の指標で確認できた。

---
🤖 Claude Code session: `$CLAUDE_SESSION_ID`