### PR TITLE
EEGバンドパワーから1/f非周期成分を分離し、θ/α系指標を実態に合わせる

### DIFF
--- a/lib/__init__.py
+++ b/lib/__init__.py
@@ -12,10 +12,14 @@ from .segment_analysis import (
 )
 from .sensors.eeg import (
     DETAILED_FREQ_BANDS,
+    FIT_RANGE_HZ,
     FREQ_BANDS,
+    MIN_REPORT_PEAK_HEIGHT,
+    PEAK_EDGE_MARGIN_HZ,
     SMR_BAND,
     AlphaPowerMethod,
     AlphaPowerResult,
+    AperiodicResult,
     FrontalAsymmetryResult,
     FrontalThetaResult,
     HarmonicsResult,  # 後方互換性
@@ -43,7 +47,10 @@ from .sensors.eeg import (
     calculate_spectrogram_all_channels,
     detect_artifact_windows,
     filter_eeg_quality,
+    find_band_peak,
+    fit_aperiodic,
     get_psd_peak_frequencies,
+    oscillatory_band_power,
     prepare_mne_raw,
     summarize_artifacts,
 )
@@ -108,6 +115,14 @@ __all__ = [
     'SMRResult',
     'calculate_smr',
     'SMR_BAND',
+    # 非周期成分（1/f）分離
+    'AperiodicResult',
+    'fit_aperiodic',
+    'find_band_peak',
+    'oscillatory_band_power',
+    'FIT_RANGE_HZ',
+    'PEAK_EDGE_MARGIN_HZ',
+    'MIN_REPORT_PEAK_HEIGHT',
     # high-level eeg utilities
     'SegmentAnalysisResult',
     'calculate_segment_analysis',

--- a/lib/report/steps_eeg.py
+++ b/lib/report/steps_eeg.py
@@ -29,11 +29,16 @@ from lib import (
     calculate_spectral_entropy_time_series,
     calculate_spectrogram_all_channels,
     filter_eeg_quality,
+    find_band_peak,
+    fit_aperiodic,
     get_psd_peak_frequencies,
+    oscillatory_band_power,
     prepare_mne_raw,
 )
 from lib.sensors.eeg.artifact import summarize_artifacts
+from lib.sensors.eeg.constants import FREQ_BANDS
 from lib.sensors.eeg.visualization import (
+    plot_aperiodic_fit,
     plot_band_power_time_series,
     plot_paf,
     plot_psd,
@@ -257,6 +262,43 @@ def prepare_mne_and_spectral(df, img_dir, results, artifact_window_samples):
             'peak': itf_dict['itf_peak'],
             'cog': itf_dict['itf_cog']
         }
+
+        # 非周期成分（1/f）分離
+        # 全チャネル平均PSDに対してspecparamでフィットする。
+        # IAF/ITFの窓内argmaxが1/fの単調減少域で窓端に張り付く問題（Issue #31）を
+        # 避けるため、ピーク検出はspecparamのイテレーティブなピーク除去に委ねる。
+        print('計算中: 非周期成分（1/f）分離...')
+        mean_psd = psd_dict['psds'].mean(axis=0)
+        aperiodic_result = fit_aperiodic(psd_dict['freqs'], mean_psd)
+        if aperiodic_result is not None:
+            theta_band = FREQ_BANDS['Theta'][:2]
+            alpha_band = FREQ_BANDS['Alpha'][:2]
+            results['aperiodic'] = {
+                'result': aperiodic_result,
+                'offset': aperiodic_result.offset,
+                'exponent': aperiodic_result.exponent,
+                'r_squared': aperiodic_result.r_squared,
+                'error': aperiodic_result.error,
+                'n_peaks': aperiodic_result.n_peaks,
+                'peaks': aperiodic_result.peaks,
+                'theta_peak': find_band_peak(aperiodic_result, theta_band),
+                'alpha_peak': find_band_peak(aperiodic_result, alpha_band),
+                'theta_osc_db': oscillatory_band_power(
+                    psd_dict['freqs'], mean_psd, aperiodic_result, theta_band
+                ),
+                'alpha_osc_db': oscillatory_band_power(
+                    psd_dict['freqs'], mean_psd, aperiodic_result, alpha_band
+                ),
+            }
+
+            print('プロット中: 非周期成分（1/f）フィット...')
+            plot_aperiodic_fit(
+                psd_dict['freqs'], mean_psd, aperiodic_result,
+                img_path=img_dir / 'aperiodic.png',
+            )
+            results['aperiodic_img'] = 'aperiodic.png'
+        else:
+            print('  警告: 非周期成分フィットに失敗したため、非周期成分セクションをスキップします。')
 
         # PSDピーク分析（SMR含む）
         analyze_psd_peaks(psd_dict, paf_dict, img_dir, results)

--- a/lib/segment_analysis.py
+++ b/lib/segment_analysis.py
@@ -121,6 +121,7 @@ def calculate_segment_analysis(
     posture_df = statistical_df.get('posture')
     hrv_df = statistical_df.get('hrv')
     respiration_df = statistical_df.get('respiration')
+    aperiodic_df = statistical_df.get('aperiodic')
     quality_df = statistical_df.get('quality')
 
     if 'TimeStamp' not in df_clean.columns:
@@ -251,6 +252,13 @@ def calculate_segment_analysis(
         if hrv_df is not None and start in hrv_df.index:
             rmssd_mean = hrv_df.loc[start, 'rmssd_mean']
 
+        # 非周期成分（1/f）を取得（オプション）
+        aperiodic_exponent = np.nan
+        aperiodic_alpha_osc_db = np.nan
+        if aperiodic_df is not None and start in aperiodic_df.index:
+            aperiodic_exponent = aperiodic_df.loc[start, 'exponent']
+            aperiodic_alpha_osc_db = aperiodic_df.loc[start, 'alpha_osc_db']
+
         # 呼吸数・RSA振幅を取得（オプション）
         br_mean = np.nan
         rsa_amp_mean = np.nan
@@ -344,6 +352,8 @@ def calculate_segment_analysis(
             'br_mean': br_mean,
             'rsa_amp_mean': rsa_amp_mean,
             'edr_amp_mean': edr_amp_mean,
+            'aperiodic_exponent': aperiodic_exponent,
+            'aperiodic_alpha_osc_db': aperiodic_alpha_osc_db,
             'yaw_rms': yaw_rms,
             'meditation_score': meditation_score,
             'excluded_ratio': excluded_ratio,
@@ -464,6 +474,8 @@ def calculate_segment_analysis(
             'RP (s)': 60 / row['br_mean'] if pd.notna(row['br_mean']) and row['br_mean'] > 0 else None,
             'RSA (ms)': row['rsa_amp_mean'],
             'EDR amp': row['edr_amp_mean'],
+            'exp': row['aperiodic_exponent'],
+            'α osc (dB)': row['aperiodic_alpha_osc_db'],
             'Yaw RMS': row['yaw_rms'],
             '除外 (%)': row['excluded_ratio'] * 100 if pd.notna(row['excluded_ratio']) else None,
             '備考': note,

--- a/lib/sensors/eeg/__init__.py
+++ b/lib/sensors/eeg/__init__.py
@@ -3,6 +3,7 @@ EEG解析ライブラリ
 Muse脳波データの周波数バンド解析、PSD、PAF計算、可視化
 """
 
+# 非周期成分（1/f）分離
 # 定数
 # Alpha Power解析
 from .alpha_power import (
@@ -10,6 +11,15 @@ from .alpha_power import (
     AlphaPowerResult,
     calculate_alpha_power,
     calculate_alpha_power_from_raw,
+)
+from .aperiodic import (
+    FIT_RANGE_HZ,
+    MIN_REPORT_PEAK_HEIGHT,
+    PEAK_EDGE_MARGIN_HZ,
+    AperiodicResult,
+    find_band_peak,
+    fit_aperiodic,
+    oscillatory_band_power,
 )
 
 # アーチファクト検出（振幅ベース）
@@ -127,4 +137,12 @@ __all__ = [
     'SMRResult',
     'calculate_smr',
     'SMR_BAND',
+    # 非周期成分（1/f）分離
+    'AperiodicResult',
+    'fit_aperiodic',
+    'find_band_peak',
+    'oscillatory_band_power',
+    'FIT_RANGE_HZ',
+    'PEAK_EDGE_MARGIN_HZ',
+    'MIN_REPORT_PEAK_HEIGHT',
 ]

--- a/lib/sensors/eeg/aperiodic.py
+++ b/lib/sensors/eeg/aperiodic.py
@@ -1,0 +1,212 @@
+"""
+非周期成分（1/f）分離モジュール
+
+specparam（旧FOOOF）でPSDを非周期成分（1/f）と周期成分（ピーク）に分離する。
+バンドパワーやargmaxベースのピーク検出は、1/fが単調減少する帯域では
+探索窓の端に張り付いた値を返してしまう（Issue #31）。specparamは
+反復的にピークを除去しながら非周期成分を当てるため、この問題を避けられる。
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Optional, Tuple
+
+import numpy as np
+import pandas as pd
+from specparam import SpectralModel
+
+# フィット範囲（Hz）。前処理で1Hzハイパスフィルタ・50/60Hzノッチフィルタが
+# 掛かっているため、フィルタの遷移帯を避けるために2-40Hzを起点にする。
+FIT_RANGE_HZ: Tuple[float, float] = (2.0, 40.0)
+
+# フィット範囲の端からこの距離（Hz）以内のピークは、実際のピークではなく
+# フィット窓の境界への張り付きとみなして棄却する。
+PEAK_EDGE_MARGIN_HZ = 0.5
+
+# この高さ（log10パワー単位）未満のピークは「検出なし」として扱う。
+# specparamのmin_peak_height未満のピークも通過することがあるため、
+# ここでも同じ閾値でガードする。
+MIN_REPORT_PEAK_HEIGHT = 0.15
+
+
+@dataclass
+class AperiodicResult:
+    """非周期成分フィット結果"""
+
+    offset: float
+    exponent: float
+    r_squared: float
+    error: float
+    peaks: pd.DataFrame = field(
+        default_factory=lambda: pd.DataFrame(columns=['center_hz', 'height', 'bandwidth_hz'])
+    )
+    fit_range: Tuple[float, float] = FIT_RANGE_HZ
+    n_peaks: int = 0
+
+
+def fit_aperiodic(
+    freqs: np.ndarray,
+    psd: np.ndarray,
+    freq_range: Tuple[float, float] = FIT_RANGE_HZ,
+    peak_width_limits: Tuple[float, float] = (1.0, 8.0),
+    max_n_peaks: int = 6,
+    min_peak_height: float = 0.15,
+    peak_threshold: float = 2.0,
+) -> Optional[AperiodicResult]:
+    """
+    PSDに非周期成分（1/f）＋周期成分（ピーク）モデルをフィットする。
+
+    Parameters
+    ----------
+    freqs : np.ndarray
+        周波数配列（Hz）。
+    psd : np.ndarray
+        パワースペクトル密度（線形スケール、μV²/Hz等）。
+    freq_range : tuple
+        フィット範囲（Hz）。
+    peak_width_limits, max_n_peaks, min_peak_height, peak_threshold
+        specparam.SpectralModel に渡すパラメータ。
+
+    Returns
+    -------
+    AperiodicResult or None
+        フィットに失敗した場合はNoneを返す。
+
+    Notes
+    -----
+    ピークは2段のガードを通過したもののみ `peaks` に含める:
+    (a) フィット範囲の下限+PEAK_EDGE_MARGIN_HZ未満、または
+        上限-PEAK_EDGE_MARGIN_HZ超のピークは棄却（窓端への張り付き対策）
+    (b) 高さがMIN_REPORT_PEAK_HEIGHT未満のピークは棄却
+    """
+    try:
+        fm = SpectralModel(
+            peak_width_limits=peak_width_limits,
+            max_n_peaks=max_n_peaks,
+            min_peak_height=min_peak_height,
+            peak_threshold=peak_threshold,
+            aperiodic_mode='fixed',
+            verbose=False,
+        )
+        fm.fit(freqs, psd, freq_range=freq_range)
+
+        ap_params = fm.get_params('aperiodic')
+        offset = float(ap_params[0])
+        exponent = float(ap_params[1])
+
+        metrics = fm.results.metrics.results
+        r_squared = float(metrics.get('gof_rsquared', np.nan))
+        error = float(metrics.get('error_mae', np.nan))
+    except Exception as e:
+        print(f'⚠️ specparamによる非周期成分フィットに失敗しました: {e}')
+        return None
+
+    low, high = freq_range
+    peak_params = fm.get_params('peak')
+
+    peak_rows = []
+    if peak_params is not None and np.asarray(peak_params).size > 0:
+        for cf, pw, bw in np.atleast_2d(peak_params):
+            if cf < low + PEAK_EDGE_MARGIN_HZ or cf > high - PEAK_EDGE_MARGIN_HZ:
+                continue
+            if pw < MIN_REPORT_PEAK_HEIGHT:
+                continue
+            peak_rows.append({
+                'center_hz': float(cf),
+                'height': float(pw),
+                'bandwidth_hz': float(bw),
+            })
+
+    peaks_df = pd.DataFrame(peak_rows, columns=['center_hz', 'height', 'bandwidth_hz'])
+
+    return AperiodicResult(
+        offset=offset,
+        exponent=exponent,
+        r_squared=r_squared,
+        error=error,
+        peaks=peaks_df,
+        fit_range=(float(low), float(high)),
+        n_peaks=len(peaks_df),
+    )
+
+
+def find_band_peak(result: AperiodicResult, band: Tuple[float, float]) -> Optional[dict]:
+    """
+    指定帯域内でガード通過済みの最も高いピークを返す。
+
+    Parameters
+    ----------
+    result : AperiodicResult
+        fit_aperiodic() の戻り値。
+    band : tuple
+        探索する周波数帯域（Hz）。
+
+    Returns
+    -------
+    dict or None
+        {'center_hz', 'height', 'bandwidth_hz'}。該当ピークが無ければNone。
+    """
+    if result is None or result.peaks.empty:
+        return None
+
+    low, high = band
+    in_band = result.peaks[
+        (result.peaks['center_hz'] >= low) & (result.peaks['center_hz'] <= high)
+    ]
+    if in_band.empty:
+        return None
+
+    best = in_band.loc[in_band['height'].idxmax()]
+    return {
+        'center_hz': float(best['center_hz']),
+        'height': float(best['height']),
+        'bandwidth_hz': float(best['bandwidth_hz']),
+    }
+
+
+def oscillatory_band_power(
+    freqs: np.ndarray,
+    psd: np.ndarray,
+    result: AperiodicResult,
+    band: Tuple[float, float],
+) -> float:
+    """
+    帯域の振動性パワーを dB で返す（実測バンドパワー ÷ 非周期成分のみのバンドパワー）。
+
+    非周期成分は specparam の fixed モードの定義に従って再構成する:
+    log10(A(f)) = offset - exponent * log10(f)  すなわち  A(f) = 10^offset / f^exponent
+    （specparam.modes.definitions の powerlaw_function に同じ。線形freq/対数power空間の線形モデル）
+
+    Parameters
+    ----------
+    freqs : np.ndarray
+        周波数配列（Hz）。
+    psd : np.ndarray
+        パワースペクトル密度（線形スケール）。
+    result : AperiodicResult
+        fit_aperiodic() の戻り値。
+    band : tuple
+        対象帯域（Hz）。
+
+    Returns
+    -------
+    float
+        振動性パワー（dB）。帯域内にデータが無い場合はNaN。
+    """
+    if result is None:
+        return float('nan')
+
+    low, high = band
+    mask = (freqs >= low) & (freqs <= high)
+    if not mask.any():
+        return float('nan')
+
+    measured_power = float(np.mean(psd[mask]))
+    aperiodic_component = (10 ** result.offset) / (freqs[mask] ** result.exponent)
+    aperiodic_power = float(np.mean(aperiodic_component))
+
+    if measured_power <= 0 or aperiodic_power <= 0:
+        return float('nan')
+
+    return float(10 * np.log10(measured_power / aperiodic_power))

--- a/lib/sensors/eeg/itf.py
+++ b/lib/sensors/eeg/itf.py
@@ -2,24 +2,34 @@
 Individual Theta Frequency (ITF) 解析モジュール
 
 瞑想中のシータ波ピーク周波数を計算します。
-マルチセッション分析（issues/017_theta_peak_validation）により、
-瞑想中のITFは約5.92 Hz（CV: 5.1%）で安定していることが確認されています。
+
+以前は窓内argmaxでピークを探していたが、PSDが1/fで単調減少する帯域では
+argmaxが必ず探索窓の下限に張り付く（測定値ではなく窓設定の産物になる）
+ことが判明した（Issue #31）。specparamによる非周期成分分離
+（`aperiodic.fit_aperiodic`）で実際にピークとして検出された場合のみ値を返し、
+検出されなければNaNを返す。
 """
 
-from ._peak_frequency_base import calculate_peak_frequency
+from __future__ import annotations
+
+from typing import Tuple
+
+import numpy as np
+
+from ._peak_frequency_base import HEMISPHERE_CONFIG
+from .aperiodic import find_band_peak, fit_aperiodic
 
 
-def calculate_itf(psd_dict, theta_range=(5.0, 7.0), use_hemisphere_average=True):
+def calculate_itf(psd_dict, theta_range: Tuple[float, float] = (4.0, 8.0), use_hemisphere_average=True):
     """
-    Individual Theta Frequency（ITF）とCenter of Gravity（CoG）を計算
+    Individual Theta Frequency（ITF）を計算
 
     Parameters
     ----------
     psd_dict : dict
         calculate_psd()の戻り値
     theta_range : tuple
-        Theta帯域の範囲（Hz）。デフォルトは(5.0, 7.0)
-        マルチセッション分析により ITF ≈ 5.92 Hz と確認済み
+        Theta帯域の範囲（Hz）。デフォルトは(4.0, 8.0)（FREQ_BANDS['Theta']に合わせる）
     use_hemisphere_average : bool
         Trueの場合、左右半球ごとにチャネルを平均化してからITFを計算
         - Left: (TP9 + AF7) / 2
@@ -32,38 +42,65 @@ def calculate_itf(psd_dict, theta_range=(5.0, 7.0), use_hemisphere_average=True)
         {
             # チャネル/半球別 {channel: {'PTF': float, 'CoG': float, 'Power': float, 'PSD': array}}
             'ptf_by_channel': dict,
-            'itf_peak': float,       # ITF Peak方式 (左右PTFの平均)
-            'itf_cog': float,        # ITF CoG方式 (左右CoGの平均)
+            'itf_peak': float,       # ITF Peak方式（θピークが検出された半球/チャネルの平均、無ければNaN）
+            'itf_cog': float,        # 常にNaN（ピーク検出ベースに変更したため概念的に意味を失った。
+                                     # キーは呼び出し側との互換性のため残す）
             'itf': float,            # ITF (itf_peakのエイリアス)
             'itf_std': float,        # ITF Peak方式の標準偏差
             'theta_range': tuple,    # Theta帯域範囲
             'theta_freqs': ndarray,  # Theta帯域の周波数配列
         }
     """
-    # 共通ロジックで計算
-    base = calculate_peak_frequency(
-        psd_dict,
-        freq_range=theta_range,
-        use_hemisphere_average=use_hemisphere_average
-    )
+    freqs = psd_dict['freqs']
+    psds = psd_dict['psds']
+    channels = psd_dict['channels']
 
-    # ITF固有のキーにマッピング
-    # PTF = Peak Theta Frequency (チャネル別のシータピーク)
+    theta_low, theta_high = theta_range
+    theta_mask = (freqs >= theta_low) & (freqs <= theta_high)
+    theta_freqs = freqs[theta_mask]
+
+    if use_hemisphere_average:
+        groups = {}
+        for hemi_name, hemi_channels in HEMISPHERE_CONFIG.items():
+            hemi_indices = [i for i, ch in enumerate(channels) if ch in hemi_channels]
+            if len(hemi_indices) >= 1:
+                groups[hemi_name] = np.mean([psds[i] for i in hemi_indices], axis=0)
+    else:
+        groups = {ch.replace('RAW_', ''): psds[i] for i, ch in enumerate(channels)}
+
     ptf_by_channel = {}
-    for label, values in base['peak_by_channel'].items():
+    for label, psd in groups.items():
+        band_psd = psd[theta_mask]
+        result = fit_aperiodic(freqs, psd)
+        peak = find_band_peak(result, theta_range) if result is not None else None
+
+        if peak is not None:
+            ptf = peak['center_hz']
+            power_idx = int(np.abs(theta_freqs - ptf).argmin())
+            power = float(band_psd[power_idx])
+        else:
+            ptf = np.nan
+            power = np.nan
+
         ptf_by_channel[label] = {
-            'PTF': values['Peak'],
-            'CoG': values['CoG'],
-            'Power': values['Power'],
-            'PSD': values['PSD'],
+            'PTF': ptf,
+            'CoG': np.nan,
+            'Power': power,
+            'PSD': band_psd,
         }
+
+    ptf_values = [v['PTF'] for v in ptf_by_channel.values()]
+    valid_ptf = [v for v in ptf_values if not np.isnan(v)]
+
+    itf_peak = float(np.mean(valid_ptf)) if valid_ptf else float('nan')
+    itf_std = float(np.std(valid_ptf)) if len(valid_ptf) > 1 else float('nan')
 
     return {
         'ptf_by_channel': ptf_by_channel,
-        'itf_peak': base['individual_peak'],
-        'itf_cog': base['individual_cog'],
-        'itf': base['individual_peak'],  # itf_peakのエイリアス
-        'itf_std': base['individual_std'],
-        'theta_range': base['band_range'],
-        'theta_freqs': base['band_freqs'],
+        'itf_peak': itf_peak,
+        'itf_cog': float('nan'),
+        'itf': itf_peak,
+        'itf_std': itf_std,
+        'theta_range': theta_range,
+        'theta_freqs': theta_freqs,
     }

--- a/lib/sensors/eeg/visualization/__init__.py
+++ b/lib/sensors/eeg/visualization/__init__.py
@@ -5,6 +5,9 @@ EEG可視化モジュール
 計算ロジックは親ディレクトリ（lib/sensors/eeg/）にあります。
 """
 
+# 非周期成分（1/f）可視化
+from .aperiodic_plot import plot_aperiodic_fit
+
 # 基本EEG可視化
 from .eeg_plots import (
     plot_band_power_time_series,
@@ -31,4 +34,6 @@ __all__ = [
     # 指標別可視化
     'plot_psd_peaks',
     'plot_harmonics',  # 後方互換性
+    # 非周期成分（1/f）可視化
+    'plot_aperiodic_fit',
 ]

--- a/lib/sensors/eeg/visualization/aperiodic_plot.py
+++ b/lib/sensors/eeg/visualization/aperiodic_plot.py
@@ -1,0 +1,86 @@
+"""
+非周期成分（1/f）分離の可視化モジュール
+"""
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+
+def plot_aperiodic_fit(freqs, psd, result, freq_range=None, img_path=None):
+    """
+    実測PSD・非周期成分（1/f）フィット・残差（振動成分）を重ねてプロットする。
+
+    Parameters
+    ----------
+    freqs : np.ndarray
+        周波数配列（Hz）。
+    psd : np.ndarray
+        パワースペクトル密度（線形スケール）。
+    result : AperiodicResult
+        aperiodic.fit_aperiodic() の戻り値。
+    freq_range : tuple, optional
+        表示する周波数範囲。Noneの場合は result.fit_range を使用。
+    img_path : str or Path, optional
+        保存先パス。
+
+    Returns
+    -------
+    fig : matplotlib.figure.Figure
+        生成された図オブジェクト
+    """
+    if freq_range is None:
+        freq_range = result.fit_range
+
+    low, high = freq_range
+    mask = (freqs >= low) & (freqs <= high)
+    plot_freqs = freqs[mask]
+    plot_psd = psd[mask]
+
+    aperiodic_fit = (10 ** result.offset) / (plot_freqs ** result.exponent)
+    residual_db = 10 * np.log10(plot_psd / aperiodic_fit)
+
+    fig, (ax1, ax2) = plt.subplots(2, 1, figsize=(10, 8), sharex=True)
+
+    # 上段: log-logで実測PSDと非周期成分フィット
+    ax1.loglog(plot_freqs, plot_psd, label='Measured PSD', color='#2196F3', linewidth=2)
+    ax1.loglog(
+        plot_freqs, aperiodic_fit,
+        label=f'Aperiodic fit (offset={result.offset:.2f}, exponent={result.exponent:.2f})',
+        color='#F44336', linewidth=2, linestyle='--',
+    )
+
+    if not result.peaks.empty:
+        for _, peak in result.peaks.iterrows():
+            ax1.axvline(peak['center_hz'], color='#4CAF50', alpha=0.4, linewidth=1.5)
+
+    ax1.set_ylabel('PSD (μV²/Hz)', fontsize=11)
+    ax1.set_title(
+        f'Aperiodic (1/f) Fit — R²={result.r_squared:.3f}, n_peaks={result.n_peaks}',
+        fontsize=13, fontweight='bold',
+    )
+    ax1.legend(fontsize=9, loc='upper right')
+    ax1.grid(True, which='both', alpha=0.3)
+
+    # 下段: 残差（振動成分、dB）
+    ax2.plot(plot_freqs, residual_db, color='#673AB7', linewidth=1.5)
+    ax2.axhline(0, color='black', linewidth=0.8, alpha=0.5)
+    if not result.peaks.empty:
+        for _, peak in result.peaks.iterrows():
+            ax2.axvline(peak['center_hz'], color='#4CAF50', alpha=0.4, linewidth=1.5)
+            ax2.annotate(
+                f"{peak['center_hz']:.2f} Hz",
+                (peak['center_hz'], residual_db[np.abs(plot_freqs - peak['center_hz']).argmin()]),
+                fontsize=8, color='#2E7D32',
+            )
+
+    ax2.set_xlabel('Frequency (Hz)', fontsize=11)
+    ax2.set_ylabel('Oscillatory residual (dB)', fontsize=11)
+    ax2.grid(True, alpha=0.3)
+
+    plt.tight_layout()
+
+    if img_path:
+        fig.savefig(img_path, dpi=150, bbox_inches='tight')
+        plt.close(fig)
+
+    return fig

--- a/lib/session_log.py
+++ b/lib/session_log.py
@@ -10,7 +10,6 @@ import os
 from pathlib import Path
 from typing import Dict, List, Optional
 
-import numpy as np
 import pandas as pd
 from google.oauth2 import service_account
 from googleapiclient.discovery import build
@@ -23,7 +22,7 @@ def _get_column_headers() -> List[str]:
     Returns
     -------
     list of str
-        14個のカラム名のリスト
+        20個のカラム名のリスト
     """
     return [
         'timestamp',
@@ -40,7 +39,39 @@ def _get_column_headers() -> List[str]:
         'theta_alpha_best',
         'hrv_mean',
         'hrv_best',
+        'aperiodic_exponent',
+        'aperiodic_offset',
+        'alpha_osc_db',
+        'theta_osc_db',
+        'alpha_cf_hz',
+        'theta_peak_detected',
     ]
+
+
+def _column_letter(n: int) -> str:
+    """
+    1始まりの列番号をA1記法の列文字に変換する（26列を超えるAA, AB, ...にも対応）。
+
+    Parameters
+    ----------
+    n : int
+        1始まりの列番号（1=A, 2=B, ..., 27=AA）。
+
+    Returns
+    -------
+    str
+        A1記法の列文字。
+    """
+    letters = ''
+    while n > 0:
+        n, remainder = divmod(n - 1, 26)
+        letters = chr(65 + remainder) + letters
+    return letters
+
+
+def _header_last_column() -> str:
+    """`_get_column_headers()` の列数からA1記法の最終列文字を求める。"""
+    return _column_letter(len(_get_column_headers()))
 
 
 def _extract_session_data(results: Dict) -> Dict:
@@ -55,10 +86,7 @@ def _extract_session_data(results: Dict) -> Dict:
     Returns
     -------
     dict
-        セッションデータの辞書。以下のキーを含む：
-        - timestamp: セッション開始時刻文字列 (YYYY-MM-DD HH:MM:SS)
-        - duration_min: 計測時間（分）
-        - fm_theta_mean, fm_theta_best, ...（全12カラム分）
+        セッションデータの辞書。`_get_column_headers()` と同じキー・順序を持つ。
 
     Raises
     ------
@@ -69,6 +97,9 @@ def _extract_session_data(results: Dict) -> Dict:
     info = results.get('data_info', {})
     mean_metrics = results.get('mean_metrics', {})
     best_metrics = results.get('best_metrics', {})
+    # 非周期成分（1/f）はmean_metrics/best_metricsに載らないため、
+    # resultsから直接読む（追加し忘れるとサイレントに欠落するため注意）。
+    aperiodic_info = results.get('aperiodic', {})
 
     # タイムスタンプ（記録開始時刻）
     start_time = info.get('start_time')
@@ -79,24 +110,33 @@ def _extract_session_data(results: Dict) -> Dict:
 
     # 計測時間（分）
     duration_sec = info.get('duration_sec')
-    duration_min = duration_sec / 60.0 if duration_sec is not None else np.nan
+    duration_min = duration_sec / 60.0 if duration_sec is not None else float('nan')
+
+    alpha_peak = aperiodic_info.get('alpha_peak')
+    theta_peak = aperiodic_info.get('theta_peak')
 
     # セッションデータ
     return {
         'timestamp': timestamp_str,
         'duration_min': duration_min,
-        'fm_theta_mean': mean_metrics.get('fm_theta_mean', np.nan),
-        'fm_theta_best': best_metrics.get('fm_theta_best', np.nan),
-        'iaf_mean': mean_metrics.get('iaf_mean', np.nan),
-        'iaf_best': best_metrics.get('iaf_best', np.nan),
-        'alpha_mean': mean_metrics.get('alpha_mean', np.nan),
-        'alpha_best': best_metrics.get('alpha_best', np.nan),
-        'beta_mean': mean_metrics.get('beta_mean', np.nan),
-        'beta_best': best_metrics.get('beta_best', np.nan),
-        'theta_alpha_mean': mean_metrics.get('theta_alpha_mean', np.nan),
-        'theta_alpha_best': best_metrics.get('theta_alpha_best', np.nan),
-        'hrv_mean': mean_metrics.get('hrv_mean', np.nan),
-        'hrv_best': best_metrics.get('hrv_best', np.nan),
+        'fm_theta_mean': mean_metrics.get('fm_theta_mean', float('nan')),
+        'fm_theta_best': best_metrics.get('fm_theta_best', float('nan')),
+        'iaf_mean': mean_metrics.get('iaf_mean', float('nan')),
+        'iaf_best': best_metrics.get('iaf_best', float('nan')),
+        'alpha_mean': mean_metrics.get('alpha_mean', float('nan')),
+        'alpha_best': best_metrics.get('alpha_best', float('nan')),
+        'beta_mean': mean_metrics.get('beta_mean', float('nan')),
+        'beta_best': best_metrics.get('beta_best', float('nan')),
+        'theta_alpha_mean': mean_metrics.get('theta_alpha_mean', float('nan')),
+        'theta_alpha_best': best_metrics.get('theta_alpha_best', float('nan')),
+        'hrv_mean': mean_metrics.get('hrv_mean', float('nan')),
+        'hrv_best': best_metrics.get('hrv_best', float('nan')),
+        'aperiodic_exponent': aperiodic_info.get('exponent', float('nan')),
+        'aperiodic_offset': aperiodic_info.get('offset', float('nan')),
+        'alpha_osc_db': aperiodic_info.get('alpha_osc_db', float('nan')),
+        'theta_osc_db': aperiodic_info.get('theta_osc_db', float('nan')),
+        'alpha_cf_hz': alpha_peak['center_hz'] if alpha_peak is not None else float('nan'),
+        'theta_peak_detected': theta_peak is not None,
     }
 
 
@@ -114,6 +154,7 @@ def write_to_csv(
         - 'data_info': {'start_time': pd.Timestamp, 'duration_sec': float}
         - 'mean_metrics': {'fm_theta_mean': float, 'iaf_mean': float, ...}
         - 'best_metrics': {'fm_theta_best': float, 'iaf_best': float, ...}
+        - 'aperiodic': {'exponent': float, 'offset': float, ...}（あれば）
     csv_path : Path, optional
         出力先CSVファイルパス。指定しない場合は
         'issues/007_daily_dashboard/session_log.csv' を使用。
@@ -125,7 +166,7 @@ def write_to_csv(
 
     Notes
     -----
-    CSVスキーマ（14カラム）:
+    CSVスキーマ（20カラム、`_get_column_headers()` が唯一の真実の源）:
     - timestamp: セッション開始時刻 (YYYY-MM-DD HH:MM:SS)
     - duration_min: 計測時間（分）
     - fm_theta_mean: Fmθ平均 (dB)
@@ -140,6 +181,12 @@ def write_to_csv(
     - theta_alpha_best: θ/α比最良値 (ratio)
     - hrv_mean: HRV (RMSSD) 平均 (ms)
     - hrv_best: HRV (RMSSD) 最良値 (ms)
+    - aperiodic_exponent: 非周期成分exponent
+    - aperiodic_offset: 非周期成分offset
+    - alpha_osc_db: α振動性パワー (dB)
+    - theta_osc_db: θ振動性パワー (dB)
+    - alpha_cf_hz: specparam由来のαピーク中心周波数 (Hz)
+    - theta_peak_detected: θピークが検出されたか (bool)
     """
     # デフォルトのCSVパス
     if csv_path is None:
@@ -196,6 +243,8 @@ def write_to_google_sheets(
     - データは既存データの末尾に追記されます
     - 最初の行がヘッダー行として扱われます
     - GitHub Actionsでは環境変数 GDRIVE_CREDS_JSON から認証情報を読み込みます
+    - 読み取り・ヘッダー書き込み・追記のレンジは `_get_column_headers()` の列数から
+      動的に算出する（列数が変わった際にA:Nのようなハードコードとズレるのを防ぐ）。
     """
     import json
 
@@ -230,6 +279,7 @@ def write_to_google_sheets(
 
     # データ抽出
     session_data = _extract_session_data(results)
+    last_col = _header_last_column()
 
     # 新しい行のデータ（文字列にフォーマット）
     new_row = []
@@ -237,7 +287,9 @@ def write_to_google_sheets(
         value = session_data[key]
         if key == 'timestamp':
             new_row.append(value)
-        elif np.isnan(value):
+        elif isinstance(value, bool):
+            new_row.append('TRUE' if value else 'FALSE')
+        elif pd.isna(value):
             new_row.append('')
         else:
             new_row.append(f'{value:.3f}')
@@ -246,7 +298,7 @@ def write_to_google_sheets(
     try:
         result = service.spreadsheets().values().get(
             spreadsheetId=spreadsheet_id,
-            range=f'{sheet_name}!A:N',
+            range=f'{sheet_name}!A:{last_col}',
         ).execute()
         values = result.get('values', [])
     except Exception:
@@ -259,7 +311,7 @@ def write_to_google_sheets(
         header_body = {'values': [_get_column_headers()]}
         service.spreadsheets().values().update(
             spreadsheetId=spreadsheet_id,
-            range=f'{sheet_name}!A1:N1',
+            range=f'{sheet_name}!A1:{last_col}1',
             valueInputOption='USER_ENTERED',
             body=header_body,
         ).execute()
@@ -267,7 +319,7 @@ def write_to_google_sheets(
 
     # 新しい行を追加
     next_row = len(values) + 1
-    range_name = f'{sheet_name}!A{next_row}:N{next_row}'
+    range_name = f'{sheet_name}!A{next_row}:{last_col}{next_row}'
 
     # データを書き込み
     body = {'values': [new_row]}

--- a/lib/session_summary.py
+++ b/lib/session_summary.py
@@ -161,6 +161,21 @@ def generate_session_summary(
         faa_df = results['faa_stats']
         summary['faa_mean'] = extract_metric_value(faa_df, 'Mean FAA')
 
+    # 非周期成分（1/f）分離
+    # mean_metrics/best_metricsには載らないため、resultsから直接読む。
+    if 'aperiodic' in results:
+        aperiodic_info = results['aperiodic']
+        summary['aperiodic_exponent'] = aperiodic_info.get('exponent')
+        summary['aperiodic_offset'] = aperiodic_info.get('offset')
+        summary['alpha_osc_db'] = aperiodic_info.get('alpha_osc_db')
+        summary['theta_osc_db'] = aperiodic_info.get('theta_osc_db')
+
+        alpha_peak = aperiodic_info.get('alpha_peak')
+        summary['alpha_cf_hz'] = alpha_peak['center_hz'] if alpha_peak is not None else None
+
+        theta_peak = aperiodic_info.get('theta_peak')
+        summary['theta_peak_detected'] = theta_peak is not None
+
     # 総合スコア
     if 'session_score' in results:
         summary['session_score'] = results['session_score']

--- a/lib/statistical_dataframe.py
+++ b/lib/statistical_dataframe.py
@@ -13,6 +13,7 @@ import numpy as np
 import pandas as pd
 from scipy import stats
 
+from .sensors.eeg.aperiodic import find_band_peak, fit_aperiodic, oscillatory_band_power
 from .sensors.eeg.artifact import (
     ARTIFACT_P2P_THRESHOLD_UV,
     ARTIFACT_WINDOW_SAMPLES,
@@ -20,6 +21,7 @@ from .sensors.eeg.artifact import (
     detect_artifact_windows,
     segment_valid_ratio,
 )
+from .sensors.eeg.constants import FREQ_BANDS
 
 # Spectral Entropy計算関数をインポート
 from .sensors.eeg.spectral_entropy import _calculate_shannon_entropy
@@ -352,30 +354,72 @@ def create_statistical_dataframe(
     # IAF時系列をSeriesに変換
     iaf_series = pd.Series(iaf_values, index=timestamps)
 
-    # ITF（Individual Theta Frequency）計算
-    # セグメントごとにシータ帯域のピーク周波数を計算
+    # ITF（Individual Theta Frequency）＋ 非周期成分（1/f）分離
+    # セグメントごとにspecparamで非周期成分を分離し、シータ帯域にピークが
+    # 検出された場合のみITFを返す。
+    # 旧実装は窓内argmaxで、PSDが1/fで単調減少する帯域では必ず窓の下限に
+    # 張り付いた値を返していた（Issue #31）。窓端への張り付きではなく
+    # 実際に検出されたピークのみを返すよう置き換える。
     itf_values = []
-    theta_range = (5.0, 7.0)
+    theta_band = FREQ_BANDS['Theta'][:2]
+    alpha_band = FREQ_BANDS['Alpha'][:2]
+
+    exponent_values = []
+    offset_values = []
+    r_squared_values = []
+    theta_osc_db_values = []
+    alpha_osc_db_values = []
 
     for seg_idx in range(n_segments):
         if not segment_usable[seg_idx]:
             itf_values.append(np.nan)
+            exponent_values.append(np.nan)
+            offset_values.append(np.nan)
+            r_squared_values.append(np.nan)
+            theta_osc_db_values.append(np.nan)
+            alpha_osc_db_values.append(np.nan)
             continue
 
-        # シータ帯域のマスク
-        theta_mask = (freqs >= theta_range[0]) & (freqs <= theta_range[1])
-        theta_freqs = freqs[theta_mask]
+        # 有効チャネルの平均PSD（全帯域）
+        psd_avg = np.nanmean(psds[seg_idx], axis=0)
+        aperiodic_result = fit_aperiodic(freqs, psd_avg)
 
-        # 有効チャネルの平均PSD（シータ帯域）
-        psd_theta_avg = np.nanmean(psds[seg_idx][:, theta_mask], axis=0)
+        if aperiodic_result is None:
+            itf_values.append(np.nan)
+            exponent_values.append(np.nan)
+            offset_values.append(np.nan)
+            r_squared_values.append(np.nan)
+            theta_osc_db_values.append(np.nan)
+            alpha_osc_db_values.append(np.nan)
+            continue
 
-        # ピーク周波数を検出
-        peak_idx = psd_theta_avg.argmax()
-        itf = theta_freqs[peak_idx]
-        itf_values.append(itf)
+        theta_peak = find_band_peak(aperiodic_result, theta_band)
+        itf_values.append(theta_peak['center_hz'] if theta_peak is not None else np.nan)
+
+        exponent_values.append(aperiodic_result.exponent)
+        offset_values.append(aperiodic_result.offset)
+        r_squared_values.append(aperiodic_result.r_squared)
+        theta_osc_db_values.append(
+            oscillatory_band_power(freqs, psd_avg, aperiodic_result, theta_band)
+        )
+        alpha_osc_db_values.append(
+            oscillatory_band_power(freqs, psd_avg, aperiodic_result, alpha_band)
+        )
 
     # ITF時系列をSeriesに変換
     itf_series = pd.Series(itf_values, index=timestamps)
+
+    # 非周期成分（1/f）時系列をDataFrameに変換
+    aperiodic_df = pd.DataFrame(
+        {
+            'exponent': exponent_values,
+            'offset': offset_values,
+            'alpha_osc_db': alpha_osc_db_values,
+            'theta_osc_db': theta_osc_db_values,
+            'r_squared': r_squared_values,
+        },
+        index=timestamps,
+    )
 
     # バンド比率計算
     ratios_dict = {}
@@ -749,6 +793,7 @@ def create_statistical_dataframe(
         'spectral_entropy': se_df,
         'iaf': iaf_series,
         'itf': itf_series,
+        'aperiodic': aperiodic_df,
         'fnirs': fnirs_df,
         'hr': hr_df,
         'posture': posture_df,

--- a/lib/templates/formatters.py
+++ b/lib/templates/formatters.py
@@ -127,37 +127,51 @@ def format_aperiodic_stats(aperiodic_info: dict) -> pd.DataFrame:
     >>> print(df.columns.tolist())
     ['Metric', 'Value', 'Unit']
     """
+    def _decimal(value) -> str:
+        """小数3桁。未測定はN/A（既存の format_score と同じ表記）"""
+        return 'N/A' if value is None or pd.isna(value) else f'{value:.3f}'
+
+    def _count(value) -> str:
+        return 'N/A' if value is None or pd.isna(value) else f'{int(value)}'
+
+    def _peak_cf(peak) -> str:
+        """ピーク未検出は中心周波数が定義できない。数値を捏造せずN/Aを返す"""
+        return 'N/A' if peak is None else _decimal(peak['center_hz'])
+
     stats = [
-        {'Metric': 'Exponent', 'Value': aperiodic_info['exponent'], 'Unit': 'a.u.'},
-        {'Metric': 'Offset', 'Value': aperiodic_info['offset'], 'Unit': 'a.u.'},
-        {'Metric': 'Fit R²', 'Value': aperiodic_info['r_squared'], 'Unit': 'ratio'},
-        {'Metric': 'Fit Error (MAE)', 'Value': aperiodic_info['error'], 'Unit': 'a.u.'},
-        {'Metric': 'Detected Peaks', 'Value': aperiodic_info['n_peaks'], 'Unit': 'count'},
+        {'Metric': 'Exponent', 'Value': _decimal(aperiodic_info['exponent']), 'Unit': 'a.u.'},
+        {'Metric': 'Offset', 'Value': _decimal(aperiodic_info['offset']), 'Unit': 'a.u.'},
+        {'Metric': 'Fit R²', 'Value': _decimal(aperiodic_info['r_squared']), 'Unit': 'ratio'},
+        {'Metric': 'Fit Error (MAE)', 'Value': _decimal(aperiodic_info['error']), 'Unit': 'a.u.'},
+        {'Metric': 'Detected Peaks', 'Value': _count(aperiodic_info['n_peaks']), 'Unit': 'count'},
+        {'Metric': 'Theta Peak (CF)', 'Value': _peak_cf(aperiodic_info.get('theta_peak')), 'Unit': 'Hz'},
+        {'Metric': 'Alpha Peak (CF)', 'Value': _peak_cf(aperiodic_info.get('alpha_peak')), 'Unit': 'Hz'},
+        {'Metric': 'Theta Oscillatory Power', 'Value': _decimal(aperiodic_info['theta_osc_db']), 'Unit': 'dB'},
+        {'Metric': 'Alpha Oscillatory Power', 'Value': _decimal(aperiodic_info['alpha_osc_db']), 'Unit': 'dB'},
     ]
 
-    theta_peak = aperiodic_info.get('theta_peak')
-    stats.append({
-        'Metric': 'Theta Peak (CF)',
-        'Value': theta_peak['center_hz'] if theta_peak is not None else float('nan'),
-        'Unit': 'Hz',
-    })
-
-    alpha_peak = aperiodic_info.get('alpha_peak')
-    stats.append({
-        'Metric': 'Alpha Peak (CF)',
-        'Value': alpha_peak['center_hz'] if alpha_peak is not None else float('nan'),
-        'Unit': 'Hz',
-    })
-
-    stats.append({
-        'Metric': 'Theta Oscillatory Power',
-        'Value': aperiodic_info['theta_osc_db'],
-        'Unit': 'dB',
-    })
-    stats.append({
-        'Metric': 'Alpha Oscillatory Power',
-        'Value': aperiodic_info['alpha_osc_db'],
-        'Unit': 'dB',
-    })
-
     return pd.DataFrame(stats)
+
+
+def format_aperiodic_peaks(peaks: pd.DataFrame) -> pd.DataFrame:
+    """
+    検出ピーク一覧を表示用の列名に整える
+
+    Parameters
+    ----------
+    peaks : pd.DataFrame
+        AperiodicResult.peaks（列: center_hz, height, bandwidth_hz）
+
+    Returns
+    -------
+    pd.DataFrame
+        表示用に列名を整えたDataFrame。入力が空なら空のまま返す。
+    """
+    if peaks is None or peaks.empty:
+        return peaks
+
+    return peaks.rename(columns={
+        'center_hz': 'Center (Hz)',
+        'height': 'Height',
+        'bandwidth_hz': 'Bandwidth (Hz)',
+    })

--- a/lib/templates/formatters.py
+++ b/lib/templates/formatters.py
@@ -102,3 +102,62 @@ def format_respiratory_stats(respiration_result: Any) -> pd.DataFrame:
         })
 
     return pd.DataFrame(stats)
+
+
+def format_aperiodic_stats(aperiodic_info: dict) -> pd.DataFrame:
+    """
+    results['aperiodic'] dictをテーブル用DataFrameに変換
+
+    Parameters
+    ----------
+    aperiodic_info : dict
+        lib.report.steps_eeg.prepare_mne_and_spectral() が
+        results['aperiodic'] に格納する辞書。
+        {'offset', 'exponent', 'r_squared', 'error', 'n_peaks',
+         'theta_peak', 'alpha_peak', 'theta_osc_db', 'alpha_osc_db'}
+
+    Returns
+    -------
+    pd.DataFrame
+        Metric/Value/Unitの3カラムを持つDataFrame
+
+    Examples
+    --------
+    >>> df = format_aperiodic_stats(results['aperiodic'])
+    >>> print(df.columns.tolist())
+    ['Metric', 'Value', 'Unit']
+    """
+    stats = [
+        {'Metric': 'Exponent', 'Value': aperiodic_info['exponent'], 'Unit': 'a.u.'},
+        {'Metric': 'Offset', 'Value': aperiodic_info['offset'], 'Unit': 'a.u.'},
+        {'Metric': 'Fit R²', 'Value': aperiodic_info['r_squared'], 'Unit': 'ratio'},
+        {'Metric': 'Fit Error (MAE)', 'Value': aperiodic_info['error'], 'Unit': 'a.u.'},
+        {'Metric': 'Detected Peaks', 'Value': aperiodic_info['n_peaks'], 'Unit': 'count'},
+    ]
+
+    theta_peak = aperiodic_info.get('theta_peak')
+    stats.append({
+        'Metric': 'Theta Peak (CF)',
+        'Value': theta_peak['center_hz'] if theta_peak is not None else float('nan'),
+        'Unit': 'Hz',
+    })
+
+    alpha_peak = aperiodic_info.get('alpha_peak')
+    stats.append({
+        'Metric': 'Alpha Peak (CF)',
+        'Value': alpha_peak['center_hz'] if alpha_peak is not None else float('nan'),
+        'Unit': 'Hz',
+    })
+
+    stats.append({
+        'Metric': 'Theta Oscillatory Power',
+        'Value': aperiodic_info['theta_osc_db'],
+        'Unit': 'dB',
+    })
+    stats.append({
+        'Metric': 'Alpha Oscillatory Power',
+        'Value': aperiodic_info['alpha_osc_db'],
+        'Unit': 'dB',
+    })
+
+    return pd.DataFrame(stats)

--- a/lib/templates/renderer.py
+++ b/lib/templates/renderer.py
@@ -10,7 +10,11 @@ from pathlib import Path
 
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 
-from lib.templates.formatters import format_aperiodic_stats, format_respiratory_stats
+from lib.templates.formatters import (
+    format_aperiodic_peaks,
+    format_aperiodic_stats,
+    format_respiratory_stats,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -287,7 +291,7 @@ class MeditationReportRenderer:
             context['aperiodic'] = {
                 'img': results.get('aperiodic_img'),
                 'stats': format_aperiodic_stats(results['aperiodic']),
-                'peaks': results['aperiodic'].get('peaks'),
+                'peaks': format_aperiodic_peaks(results['aperiodic'].get('peaks')),
             }
 
         # 時間セグメント分析

--- a/lib/templates/renderer.py
+++ b/lib/templates/renderer.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 
-from lib.templates.formatters import format_respiratory_stats
+from lib.templates.formatters import format_aperiodic_stats, format_respiratory_stats
 
 logger = logging.getLogger(__name__)
 
@@ -281,6 +281,14 @@ class MeditationReportRenderer:
         # 姿勢分析（ネスト構造をそのままコピー）
         if 'posture' in results:
             context['posture'] = results['posture']
+
+        # 非周期成分（1/f）分析
+        if 'aperiodic' in results:
+            context['aperiodic'] = {
+                'img': results.get('aperiodic_img'),
+                'stats': format_aperiodic_stats(results['aperiodic']),
+                'peaks': results['aperiodic'].get('peaks'),
+            }
 
         # 時間セグメント分析
         if 'segment_plot' in results or 'segment_table' in results:

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ scipy>=1.11
 
 # EEG Signal Processing
 mne>=1.10
+specparam==2.0.0rc7  # 1/f非周期成分分離（RC版のためピン留め、API変更の可能性あり）
 
 # HRV & Neurophysiological Signal Processing
 neurokit2>=0.2.12

--- a/templates/meditation/report.md.j2
+++ b/templates/meditation/report.md.j2
@@ -37,6 +37,10 @@
 {% include "meditation/sections/posture.md.j2" %}
 {% endif %}
 
+{% if aperiodic %}
+{% include "meditation/sections/aperiodic.md.j2" %}
+{% endif %}
+
 {% if segments %}
 {% include "meditation/sections/time_segment.md.j2" %}
 {% endif %}

--- a/templates/meditation/sections/aperiodic.md.j2
+++ b/templates/meditation/sections/aperiodic.md.j2
@@ -10,7 +10,7 @@
 
 {% endif %}
 {% if aperiodic.stats is not none %}
-{{ aperiodic.stats|df_to_markdown(floatfmt='.3f', index=False, standardize_columns=True) }}
+{{ aperiodic.stats|df_to_markdown(index=False, standardize_columns=True) }}
 
 {% endif %}
 {% if aperiodic.peaks is not none and not aperiodic.peaks.empty %}

--- a/templates/meditation/sections/aperiodic.md.j2
+++ b/templates/meditation/sections/aperiodic.md.j2
@@ -1,0 +1,32 @@
+## 🌊 非周期成分（1/f）分析
+
+セッション全体の平均PSDに対して非周期成分（1/f）と周期成分（ピーク）を分離した結果です。
+バンドパワーやIAF/ITFの窓内argmaxは、PSDが1/fで単調減少する帯域では探索窓の端に
+張り付いた値を返すことがあります。specparamで非周期成分を差し引くことで、
+実際に振動として検出されたピークのみを扱います。
+
+{% if aperiodic.img %}
+![非周期成分フィット](img/{{ aperiodic.img }})
+
+{% endif %}
+{% if aperiodic.stats is not none %}
+{{ aperiodic.stats|df_to_markdown(floatfmt='.3f', index=False, standardize_columns=True) }}
+
+{% endif %}
+{% if aperiodic.peaks is not none and not aperiodic.peaks.empty %}
+### 検出されたピーク
+
+{{ aperiodic.peaks|df_to_markdown(floatfmt='.3f', index=False, standardize_columns=True) }}
+
+{% else %}
+検出されたピークはありません（ガード条件: フィット範囲端から0.5Hz以内、または高さ0.15未満のピークは棄却）。
+
+{% endif %}
+> **留保**:
+> - **Museの電極配置の限界**: AF7/AF8はfrontal midline thetaの発生源（Fz近傍）から
+>   外れています。「θ振動が検出されない」は「θが出ていない」より弱い主張であり、
+>   解析手法だけでは解決しません。電極配置由来の限界として読んでください。
+> - **exponentの解釈**: 興奮/抑制バランスの指標とする議論はありますが確立していません。
+>   セッション内の相対推移を追う量として扱い、絶対値に生理学的意味を読み込まないでください。
+
+

--- a/tests/test_aperiodic.py
+++ b/tests/test_aperiodic.py
@@ -1,0 +1,245 @@
+"""
+非周期成分（1/f）分離モジュールの真値検証テスト
+
+合成PSD（既知のexponent/offset、既知のピーク中心周波数・高さ）を使い、
+fit_aperiodic / find_band_peak / oscillatory_band_power が期待値を
+復元できるかを確認する。
+
+specparam自体が持つエッジ除外・SNR閾値の挙動と、本モジュールが追加で
+かけているガード（PEAK_EDGE_MARGIN_HZ / MIN_REPORT_PEAK_HEIGHT）を
+区別して検証するため、ガードのテストはspecparamの出力をモックして行う
+（specparamは端に近いピークやごく小さいピークをそもそも検出しないことが
+多く、実データだけではこちらのガードが実際に効く場面を再現しにくいため）。
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+from lib.sensors.eeg.aperiodic import (
+    FIT_RANGE_HZ,
+    MIN_REPORT_PEAK_HEIGHT,
+    PEAK_EDGE_MARGIN_HZ,
+    find_band_peak,
+    fit_aperiodic,
+    oscillatory_band_power,
+)
+
+
+def _synthesize_psd(offset, exponent, freqs, peak_cf=None, peak_height=0.0, peak_bw=1.5, noise=0.01, seed=0):
+    """
+    1/f（＋任意でガウシアンピーク）の合成PSDを生成する。
+
+    log10(PSD) = offset - exponent * log10(f) + peak_height * exp(-(f-cf)^2 / (2*bw^2))
+    """
+    rng = np.random.default_rng(seed)
+    aperiodic = 10 ** offset / freqs ** exponent
+    if peak_cf is not None and peak_height > 0:
+        peak_log = peak_height * np.exp(-0.5 * ((freqs - peak_cf) / peak_bw) ** 2)
+        psd = aperiodic * (10 ** peak_log)
+    else:
+        psd = aperiodic
+    psd = psd * (1 + noise * rng.standard_normal(len(freqs)))
+    return np.abs(psd)
+
+
+class TestFitAperiodicRecoversAperiodicParams:
+    """既知のexponent/offsetを復元できること"""
+
+    def test_recovers_known_exponent_and_offset(self):
+        freqs = np.linspace(0.5, 45, 800)
+        true_offset, true_exponent = 1.05, 1.32
+        psd = _synthesize_psd(true_offset, true_exponent, freqs, noise=0.01, seed=1)
+
+        result = fit_aperiodic(freqs, psd)
+
+        assert result is not None
+        assert result.offset == pytest.approx(true_offset, abs=0.05)
+        assert result.exponent == pytest.approx(true_exponent, abs=0.05)
+        assert result.r_squared > 0.98
+        assert result.n_peaks == 0
+        assert result.peaks.empty
+
+    def test_higher_exponent_recovered_too(self):
+        """複数の指数（フラットな系列と急峻な系列）でも復元できること"""
+        freqs = np.linspace(0.5, 45, 800)
+        for true_offset, true_exponent in [(0.4, 0.6), (1.5, 1.8)]:
+            psd = _synthesize_psd(true_offset, true_exponent, freqs, noise=0.01, seed=2)
+            result = fit_aperiodic(freqs, psd)
+            assert result is not None
+            assert result.offset == pytest.approx(true_offset, abs=0.1)
+            assert result.exponent == pytest.approx(true_exponent, abs=0.1)
+
+
+class TestFitAperiodicRecoversPeak:
+    """既知のピーク（中心周波数・高さ）を復元できること"""
+
+    def test_recovers_known_alpha_peak(self):
+        freqs = np.linspace(0.5, 45, 1000)
+        true_offset, true_exponent = 1.0, 1.3
+        true_cf, true_height = 10.0, 0.6
+        psd = _synthesize_psd(
+            true_offset, true_exponent, freqs,
+            peak_cf=true_cf, peak_height=true_height, peak_bw=1.5,
+            noise=0.005, seed=3,
+        )
+
+        result = fit_aperiodic(freqs, psd)
+
+        assert result is not None
+        assert result.n_peaks == 1
+        peak = result.peaks.iloc[0]
+        assert peak['center_hz'] == pytest.approx(true_cf, abs=0.3)
+        assert peak['height'] == pytest.approx(true_height, abs=0.15)
+
+        band_peak = find_band_peak(result, (8.0, 13.0))
+        assert band_peak is not None
+        assert band_peak['center_hz'] == pytest.approx(true_cf, abs=0.3)
+
+
+class TestFindBandPeakNoFalsePositive:
+    """ピークが無い合成データで誤検出しないこと"""
+
+    def test_no_peak_returns_none(self):
+        freqs = np.linspace(0.5, 45, 800)
+        psd = _synthesize_psd(1.0, 1.3, freqs, noise=0.01, seed=4)
+
+        result = fit_aperiodic(freqs, psd)
+
+        assert result is not None
+        assert result.n_peaks == 0
+        assert find_band_peak(result, (4.0, 8.0)) is None
+        assert find_band_peak(result, (8.0, 13.0)) is None
+
+
+def _make_mock_specparam(ap_params, peak_params, metrics=None):
+    """specparam.SpectralModelの戻り値をモックする。"""
+    mock_fm = MagicMock()
+    mock_fm.get_params.side_effect = lambda kind: (
+        np.asarray(ap_params) if kind == 'aperiodic' else np.asarray(peak_params)
+    )
+    mock_fm.results.metrics.results = metrics or {'error_mae': 0.01, 'gof_rsquared': 0.98}
+    return mock_fm
+
+
+class TestPeakEdgeGuard:
+    """フィット範囲の端に立てたピークがPEAK_EDGE_MARGIN_HZガードで棄却されること"""
+
+    def test_peak_near_low_edge_is_rejected(self):
+        low, high = FIT_RANGE_HZ
+        edge_cf = low + PEAK_EDGE_MARGIN_HZ - 0.1  # ガード境界のすぐ内側（棄却されるべき）
+        mock_fm = _make_mock_specparam(
+            ap_params=[1.0, 1.3],
+            peak_params=[[edge_cf, 0.5, 1.0]],
+        )
+        with patch('lib.sensors.eeg.aperiodic.SpectralModel', return_value=mock_fm):
+            freqs = np.linspace(0.5, 45, 100)
+            psd = np.ones_like(freqs)
+            result = fit_aperiodic(freqs, psd)
+
+        assert result is not None
+        assert result.n_peaks == 0
+        assert result.peaks.empty
+
+    def test_peak_near_high_edge_is_rejected(self):
+        low, high = FIT_RANGE_HZ
+        edge_cf = high - PEAK_EDGE_MARGIN_HZ + 0.1  # ガード境界のすぐ内側（棄却されるべき）
+        mock_fm = _make_mock_specparam(
+            ap_params=[1.0, 1.3],
+            peak_params=[[edge_cf, 0.5, 1.0]],
+        )
+        with patch('lib.sensors.eeg.aperiodic.SpectralModel', return_value=mock_fm):
+            freqs = np.linspace(0.5, 45, 100)
+            psd = np.ones_like(freqs)
+            result = fit_aperiodic(freqs, psd)
+
+        assert result is not None
+        assert result.n_peaks == 0
+
+    def test_peak_well_inside_range_is_kept(self):
+        low, high = FIT_RANGE_HZ
+        inside_cf = (low + high) / 2
+        mock_fm = _make_mock_specparam(
+            ap_params=[1.0, 1.3],
+            peak_params=[[inside_cf, 0.5, 1.0]],
+        )
+        with patch('lib.sensors.eeg.aperiodic.SpectralModel', return_value=mock_fm):
+            freqs = np.linspace(0.5, 45, 100)
+            psd = np.ones_like(freqs)
+            result = fit_aperiodic(freqs, psd)
+
+        assert result is not None
+        assert result.n_peaks == 1
+        assert result.peaks.iloc[0]['center_hz'] == pytest.approx(inside_cf)
+
+
+class TestMinPeakHeightGuard:
+    """MIN_REPORT_PEAK_HEIGHT未満の微小ピークが棄却されること"""
+
+    def test_tiny_peak_is_rejected(self):
+        tiny_height = MIN_REPORT_PEAK_HEIGHT - 0.05
+        mock_fm = _make_mock_specparam(
+            ap_params=[1.0, 1.3],
+            peak_params=[[10.0, tiny_height, 1.0]],
+        )
+        with patch('lib.sensors.eeg.aperiodic.SpectralModel', return_value=mock_fm):
+            freqs = np.linspace(0.5, 45, 100)
+            psd = np.ones_like(freqs)
+            result = fit_aperiodic(freqs, psd)
+
+        assert result is not None
+        assert result.n_peaks == 0
+
+    def test_peak_above_threshold_is_kept(self):
+        ok_height = MIN_REPORT_PEAK_HEIGHT + 0.05
+        mock_fm = _make_mock_specparam(
+            ap_params=[1.0, 1.3],
+            peak_params=[[10.0, ok_height, 1.0]],
+        )
+        with patch('lib.sensors.eeg.aperiodic.SpectralModel', return_value=mock_fm):
+            freqs = np.linspace(0.5, 45, 100)
+            psd = np.ones_like(freqs)
+            result = fit_aperiodic(freqs, psd)
+
+        assert result is not None
+        assert result.n_peaks == 1
+        assert result.peaks.iloc[0]['height'] == pytest.approx(ok_height)
+
+
+class TestOscillatoryBandPower:
+    """振動性バンドパワーが既知の高さに対して期待通りのdBを返すこと"""
+
+    def test_recovers_expected_db_for_known_peak(self):
+        freqs = np.linspace(0.5, 45, 1000)
+        true_offset, true_exponent = 1.0, 1.3
+        true_cf, true_height = 10.0, 0.6
+        psd = _synthesize_psd(
+            true_offset, true_exponent, freqs,
+            peak_cf=true_cf, peak_height=true_height, peak_bw=1.5,
+            noise=0.002, seed=5,
+        )
+
+        result = fit_aperiodic(freqs, psd)
+        assert result is not None
+
+        # ピーク帯域中心付近の狭い帯域で評価し、非周期成分とのdB差が
+        # ほぼpeak_height * 10（log10パワー→dB換算）に一致することを確認する。
+        band = (true_cf - 0.5, true_cf + 0.5)
+        db = oscillatory_band_power(freqs, psd, result, band)
+
+        expected_db = true_height * 10  # log10パワーのpeak_heightは10倍するとdB相当
+        assert db == pytest.approx(expected_db, abs=2.0)
+
+    def test_zero_for_pure_aperiodic_signal(self):
+        """ピークが無ければ振動性パワーはほぼ0dBになること"""
+        freqs = np.linspace(0.5, 45, 800)
+        psd = _synthesize_psd(1.0, 1.3, freqs, noise=0.005, seed=6)
+
+        result = fit_aperiodic(freqs, psd)
+        assert result is not None
+
+        db = oscillatory_band_power(freqs, psd, result, (8.0, 13.0))
+        assert db == pytest.approx(0.0, abs=1.0)

--- a/tests/test_aperiodic.py
+++ b/tests/test_aperiodic.py
@@ -5,11 +5,11 @@
 fit_aperiodic / find_band_peak / oscillatory_band_power が期待値を
 復元できるかを確認する。
 
-specparam自体が持つエッジ除外・SNR閾値の挙動と、本モジュールが追加で
-かけているガード（PEAK_EDGE_MARGIN_HZ / MIN_REPORT_PEAK_HEIGHT）を
-区別して検証するため、ガードのテストはspecparamの出力をモックして行う
-（specparamは端に近いピークやごく小さいピークをそもそも検出しないことが
-多く、実データだけではこちらのガードが実際に効く場面を再現しにくいため）。
+ガード（PEAK_EDGE_MARGIN_HZ / MIN_REPORT_PEAK_HEIGHT）のテストは
+specparamの出力をモックして行う。実データではガードは実際に発火しており
+（例: フィット下限ちょうどの2.00Hz、min_peak_heightを下回る高さ0.06の
+ピークがspecparamから返る）、モックは「発火しないから」ではなく
+data/ がgitignoreされておりCIで実データテストが全skipになるためである。
 """
 
 from __future__ import annotations
@@ -17,6 +17,7 @@ from __future__ import annotations
 from unittest.mock import MagicMock, patch
 
 import numpy as np
+import pandas as pd
 import pytest
 
 from lib.sensors.eeg.aperiodic import (
@@ -27,6 +28,7 @@ from lib.sensors.eeg.aperiodic import (
     fit_aperiodic,
     oscillatory_band_power,
 )
+from lib.templates.formatters import format_aperiodic_peaks, format_aperiodic_stats
 
 
 def _synthesize_psd(offset, exponent, freqs, peak_cf=None, peak_height=0.0, peak_bw=1.5, noise=0.01, seed=0):
@@ -243,3 +245,62 @@ class TestOscillatoryBandPower:
 
         db = oscillatory_band_power(freqs, psd, result, (8.0, 13.0))
         assert db == pytest.approx(0.0, abs=1.0)
+
+
+class TestAperiodicFormatters:
+    """レポート表示用フォーマッタ"""
+
+    @staticmethod
+    def _info(theta_peak=None, alpha_peak=None):
+        return {
+            'exponent': 1.3402,
+            'offset': 1.0814,
+            'r_squared': 0.9431,
+            'error': 0.0752,
+            'n_peaks': 5,
+            'theta_peak': theta_peak,
+            'alpha_peak': alpha_peak,
+            'theta_osc_db': 0.1678,
+            'alpha_osc_db': 6.3729,
+        }
+
+    def _value_of(self, df, metric):
+        return df.loc[df['Metric'] == metric, 'Value'].iloc[0]
+
+    def test_undetected_peak_is_not_rendered_as_nan(self):
+        """
+        ピーク未検出は 'nan' ではなく 'N/A' で出す
+
+        生の 'nan' はクラッシュの痕跡に見え、「測定していない」という
+        意図が伝わらない。既存の format_score と同じ 'N/A' に揃える。
+        """
+        df = format_aperiodic_stats(self._info(theta_peak=None))
+
+        assert self._value_of(df, 'Theta Peak (CF)') == 'N/A'
+        assert 'nan' not in df['Value'].str.lower().tolist()
+
+    def test_detected_peak_is_rendered_with_three_decimals(self):
+        df = format_aperiodic_stats(self._info(alpha_peak={'center_hz': 8.70196}))
+
+        assert self._value_of(df, 'Alpha Peak (CF)') == '8.702'
+
+    def test_count_is_rendered_as_integer(self):
+        """count 単位の指標に小数を出さない"""
+        df = format_aperiodic_stats(self._info())
+
+        assert self._value_of(df, 'Detected Peaks') == '5'
+
+    def test_peaks_table_uses_display_column_names(self):
+        peaks = pd.DataFrame([
+            {'center_hz': 8.702, 'height': 1.147, 'bandwidth_hz': 1.0},
+        ])
+
+        formatted = format_aperiodic_peaks(peaks)
+
+        assert list(formatted.columns) == ['Center (Hz)', 'Height', 'Bandwidth (Hz)']
+
+    def test_empty_peaks_table_passes_through(self):
+        empty = pd.DataFrame(columns=['center_hz', 'height', 'bandwidth_hz'])
+
+        assert format_aperiodic_peaks(empty).empty
+        assert format_aperiodic_peaks(None) is None


### PR DESCRIPTION
## 概要

- 現行のバンドパワー系指標（Fmθ・θ/α・ITF）が「振動」ではなく「1/f背景」を測っている場面があった。ITF/IAFの窓内argmaxはPSDが1/fで単調減少する帯域では必ず探索窓の下限に張り付いた値を返す（測定値ではなく窓設定の産物）。
- specparam(2.0.0rc7)でPSDを非周期成分（1/f: offset/exponent）と周期成分（ピーク）に分離する `lib/sensors/eeg/aperiodic.py` を追加し、セッション全体・セグメント別の両方に統合した。

## 変更内容

### 新規モジュール
- `lib/sensors/eeg/aperiodic.py`: `fit_aperiodic()` / `find_band_peak()` / `oscillatory_band_power()`。ピークは (a) フィット範囲端から0.5Hz以内、(b) 高さ0.15未満、の2段ガードで棄却する。
- `lib/sensors/eeg/visualization/aperiodic_plot.py`: 実測PSD・1/fフィット・残差を重ねたプロット。

### 統合
- セッション全体: `prepare_mne_and_spectral()` で全チャネル平均PSDにフィットし `results['aperiodic']` / `results['aperiodic_img']` に格納。
- セグメント別: `statistical_dataframe.py` に exponent/offset/α振動(dB)/θ振動(dB) の時系列を追加。`segment_analysis.py` のセグメント表に `exp` / `α osc (dB)` 列を追加。
- **ITF**: 窓内argmaxをやめ、specparamでθ帯にピークが検出された場合のみ値を返す。検出されなければNaN。
- **IAF（calculate_paf）は変更なし**。Museアプリと突き合わせ済みのため主指標として維持し、specparam由来のαピーク中心周波数は `alpha_cf_hz` としてsummary.csvに併記するのみ。
- レポートに非周期成分セクションを追加（Muse電極配置の限界・exponent解釈の未確立性を明記）。
- `summary.csv` / session log に `aperiodic_exponent`, `aperiodic_offset`, `alpha_osc_db`, `theta_osc_db`, `alpha_cf_hz`, `theta_peak_detected` を追加。

### session_log.py の潜在バグ修正
- `A:N` 範囲の3箇所のハードコードを `_get_column_headers()` の列数から動的に算出するよう変更（26列超もAA表記で対応）。
- `np.isnan(value)` を `pd.isna(value)` に変更（bool/str/Noneでも安全に判定）。
- `_extract_session_data()` が非周期成分を `results['aperiodic']` から直接読むよう対応（mean_metrics/best_metricsには載らないため）。

### 依存追加
- `requirements.txt` に `specparam==2.0.0rc7` を完全ピンで追加（RC版のため）。

## 動作確認

対象セッション（`data/muse/mindMonitor_2026-08-19--07-31-44_*.csv`）で `bash scripts/run_analysis.sh <path> tmp none` を実行し、以下を確認した:

```
非周期成分（セッション全体）: offset 1.081 / exponent 1.340 / R² 0.943
検出ピーク: 8.702 / 10.108 / 12.546 / 30.080 / 38.625 Hz（θ帯にピークなし）
セグメント別 exp: 1.36 → 0.86（平坦化）
セグメント別 α osc (dB): 5.55 → 9.55（増加）
ITF (Hz) 列: 全区間NaNのためレポートから自動非表示（θピーク未検出）
summary.csv: aperiodic_exponent=1.340195, theta_peak_detected=False 等、6列すべて出力を確認
session_log.csv（ローカルCSV書き込みモードで確認）: 20列で正しく追記されることを確認
```

事前調査で確定していた基準値（offset 1.055, exponent 1.316, R² 0.966、θ帯ピークなし）と定性的に一致する。数値の細かな差はチャネル平均PSDの取り方の違いによるもの。

```bash
bash scripts/check.sh
# ruff / mypy / pytest すべて通過（tests/test_aperiodic.py 11ケース含む）
```

## Test plan

- [x] `bash scripts/check.sh` が全通過する
- [x] `bash scripts/run_analysis.sh data/muse/mindMonitor_2026-08-19--07-31-44_2439014959569401470.csv tmp none` を実行し、`tmp/REPORT.md` に非周期成分セクションが出ること・セグメント表に `exp` / `α osc (dB)` 列が出ること・ITF列がNaNのため非表示になることを確認する
- [x] `venv/bin/python -m pytest tests/test_aperiodic.py -v` で11ケースすべて通過することを確認する
- [x] `SAVE_TO=csv bash scripts/run_analysis.sh <同CSV> tmp csv` を実行し、`issues/007_daily_dashboard/session_log.csv` に20列（新規6列含む）で追記されることを確認する

Closes #31

---
🤖 Claude Code session: `$CLAUDE_SESSION_ID`